### PR TITLE
Set angular velocity to 0 if linear velocity is 0

### DIFF
--- a/ros2-waywise_teleop/src/teleop_gateway.cpp
+++ b/ros2-waywise_teleop/src/teleop_gateway.cpp
@@ -125,7 +125,7 @@ private:
         {
             // Ensure linear and angular velocities are above the minimum allowed values, else set to zero
             twist_msg->linear.x = (std::abs(twist_msg->linear.x) < min_allowed_linear_velocity_) ? 0.0 : twist_msg->linear.x;
-            twist_msg->angular.z = (std::abs(twist_msg->angular.z) < min_allowed_angular_velocity_) ? 0.0 : twist_msg->angular.z;
+            twist_msg->angular.z = (std::abs(twist_msg->angular.z) < min_allowed_angular_velocity_ || twist_msg->linear.x == 0.0) ? 0.0 : twist_msg->angular.z;
 
             gateway_publisher_->publish(*twist_msg);
         }


### PR DESCRIPTION
Currently waywise_node doesn't actuate servo when linear velocity is 0 because steering is set using curvature (1/r = w/v). But steering can be set in gazebo even when rover is at standstill. To match gazebo with reality, we can adjust angular velocity in teleop node. 