### PR TITLE
twist_keyboard: emergency_stop support and conditionally publish twist

### DIFF
--- a/waywiser_teleop/py_scripts/twist_keyboard.py
+++ b/waywiser_teleop/py_scripts/twist_keyboard.py
@@ -74,12 +74,27 @@ class TwistKeyboard(Node):
         # Define the font and its size
         self.pygame_font = pygame.font.SysFont('Arial', 16)
 
+        # Define a flag to track if the quit event has occurred
+        self.shutdown_requested = False
+
+        # Set up Pygame event handlers
+        pygame.event.set_allowed(None)  # Disable all events
+        pygame.event.set_allowed(pygame.QUIT)  # Enable quit event
+
     def capture_pressed_keys(self):
         keys = pygame.key.get_pressed()
 
+        # Check for quit event
+        for event in pygame.event.get():
+            if event.type == pygame.QUIT:
+                self.shutdown_requested = True
+
         pygame.event.pump()
 
-        return keys
+        if self.shutdown_requested:
+            return None
+        else:
+            return keys
 
     def process_speed_control_keys(self):
         # Get the state of all keys
@@ -224,7 +239,8 @@ def main():
     node = TwistKeyboard()
 
     try:
-        rclpy.spin(node)
+        while rclpy.ok() and not node.shutdown_requested:
+            rclpy.spin_once(node)
     finally:
         node.destroy_node()
         rclpy.shutdown()


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Feature enhancement and Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

  emergency_stop can only be set from joy_stick or by publishing from command line. It cannot be set from twist_keyboard.
  
  twist_keyboard node continuous publishes twist messages even when keyboard keys are not pressed. This overrides other twist topics (with low priority) and produces zero velocity twist output.

To Reproduce

* **What is the new behavior (if this is a feature change)?**

  It is possible to set (by pressing Ctrl+e) and clear (Ctrl+Shift+e) emergency_stop signal directly from twist_keyboard.
  
  twist_keyboard node only publishes messages when at least one of the actuation keys is pressed. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  No.

* **Other information**:


