### PR TITLE
handle twist timeout

### DIFF
--- a/waywiser_teleop/src/joy_emergency_stop.cpp
+++ b/waywiser_teleop/src/joy_emergency_stop.cpp
@@ -41,7 +41,21 @@ public:
 private:
   void joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
   {
-    last_joy_msg_received_time_ = this->now();
+    if (joy_watchdog_timer_->is_canceled()) {
+      if (emergency_stop_msg_.data) {
+        RCLCPP_WARN(
+          get_logger(),
+          "Receiving messages from /joy topic now, "
+          "but emergency_stop is ACTIVATED.");
+      } else {
+        RCLCPP_WARN(
+          get_logger(),
+          "Receiving messages from /joy topic now. "
+          "Monitoring emergency_stop button.");
+      }
+    }
+    joy_watchdog_timer_->reset();
+
     if (joy_msg->buttons[emergency_stop_set_joy_button_index_] == 1) {
       if (!emergency_stop_msg_.data) {
         emergency_stop_msg_.data = true;
@@ -63,38 +77,15 @@ private:
 
   void joy_watchdog_callback()
   {
-    if (last_joy_msg_received_time_.seconds() > 0) {
-      // Check if joy has started publishing messages since node is started
-      // Calculate the time elapsed since the last message was received
-      auto time_since_last_msg = (this->now() - last_joy_msg_received_time_).seconds();
-      if (time_since_last_msg > joy_emergency_stop_timeout_) {
-        if (is_joy_alive_) {
-          emergency_stop_msg_.data = true;
-          emergency_stop_publisher_->publish(emergency_stop_msg_);
-          RCLCPP_WARN(
-            get_logger(),
-            "/joy topic has stopped publishing for %.2f seconds. "
-            "emergency_stop ACTIVATED.",
-            time_since_last_msg);
-          is_joy_alive_ = false;
-        }
-      } else {
-        if (!is_joy_alive_) {
-          is_joy_alive_ = true;
-          if (emergency_stop_msg_.data) {
-            RCLCPP_WARN(
-              get_logger(),
-              "Receiving messages from /joy topic now, "
-              "but emergency_stop is ACTIVATED.");
-          } else {
-            RCLCPP_WARN(
-              get_logger(),
-              "Receiving messages from /joy topic now. "
-              "Monitoring emergency_stop button.");
-          }
-        }
-      }
-    }
+    emergency_stop_msg_.data = true;
+    emergency_stop_publisher_->publish(emergency_stop_msg_);
+    RCLCPP_WARN(
+      get_logger(),
+      "/joy topic has stopped publishing for %.2f seconds. "
+      "emergency_stop ACTIVATED.",
+      joy_emergency_stop_timeout_);
+
+    joy_watchdog_timer_->cancel();
   }
 
   // Publishers and subscribers
@@ -108,11 +99,7 @@ private:
   int emergency_stop_set_joy_button_index_;
   int emergency_stop_clear_joy_button_index_;
   float joy_emergency_stop_timeout_;
-  bool is_joy_alive_ = false;
   std_msgs::msg::Bool emergency_stop_msg_;
-  rclcpp::Time last_joy_msg_received_time_ = rclcpp::Time(
-    (int64_t)-1,
-    rcl_clock_type_t::RCL_ROS_TIME);
 };
 
 int main(int argc, char * argv[])

--- a/waywiser_twist_safety/README.md
+++ b/waywiser_twist_safety/README.md
@@ -5,6 +5,20 @@
     ros2 launch waywiser_twist_safety twist_safety.launch.py enable_collision_monitor:=true
     ros2 launch waywiser_twist_safety twist_safety.launch.py twist_safety_config:=./src/WayWiseR/waywiser_twist_safety/config/twist_safety.yaml
 
+## Set/clear emergency_stop from command line
+
+- To set emergency_stop:
+
+  ```
+  ros2 topic pub --once /emergency_stop std_msgs/msg/Bool "data: true"
+  ```
+
+- To clear emergency_stop
+
+  ```
+  ros2 topic pub --once /emergency_stop std_msgs/msg/Bool "data: false"
+  ```
+
 ## Nodes launched by twist_safety.launch.py
 
 1. **onboard_twist_mux**: node that subscribes to topics configured in twist_safety_config file, e.g., teleop_mux_vel, waywise_vel etc., and publishes to onboard_mux_vel by multiplexing between sunscribed topics according to their priorities.

--- a/waywiser_twist_safety/config/twist_safety.yaml
+++ b/waywiser_twist_safety/config/twist_safety.yaml
@@ -1,6 +1,7 @@
 emergency_stop_monitor:
   ros__parameters:
     start_with_emergency_stop: true
+    cmd_vel_in_timeout: 0.5
 
 onboard_twist_mux:
   ros__parameters:

--- a/waywiser_twist_safety/include/emergency_stop_monitor.hpp
+++ b/waywiser_twist_safety/include/emergency_stop_monitor.hpp
@@ -24,12 +24,17 @@ public:
 private:
   void emergency_stop_callback(const std_msgs::msg::Bool::SharedPtr emergency_stop_msg);
   void twist_callback(const geometry_msgs::msg::Twist::SharedPtr twist_msg);
+  void twist_watchdog_callback();
 
   rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr emergency_stop_subscriber_;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscriber_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_publisher_;
 
   bool emergency_stop_value_;
+  float cmd_vel_in_timeout_;
+
+  // Timer
+  rclcpp::TimerBase::SharedPtr twist_watchdog_timer_;
 };
 }  // namespace waywiser_twist_safety
 #endif  // WAYWISER_TWIST_SAFETY_EMERGENCY_STOP_MONITOR_HPP_

--- a/waywiser_twist_safety/package.xml
+++ b/waywiser_twist_safety/package.xml
@@ -20,6 +20,8 @@
 
   <license>GPLv3</license>
 
+  <url type="website">https://github.com/ros-planning/navigation2/tree/humble/nav2_collision_monitor</url>
+
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
@@ -32,8 +34,6 @@
   <depend>twist_mux</depend>
   <depend>nav2_collision_monitor</depend>
   <depend>nav2_lifecycle_manager</depend>
-
-  <url type="website">https://github.com/ros-planning/navigation2/tree/humble/nav2_collision_monitor</url>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/waywiser_twist_safety/src/rclcpp_components/emergency_stop_monitor_core.cpp
+++ b/waywiser_twist_safety/src/rclcpp_components/emergency_stop_monitor_core.cpp
@@ -17,6 +17,13 @@ EmergencyStopMonitor::EmergencyStopMonitor(const rclcpp::NodeOptions & options)
   emergency_stop_subscriber_ = this->create_subscription<std_msgs::msg::Bool>(
     "/emergency_stop", 10, std::bind(&EmergencyStopMonitor::emergency_stop_callback, this, _1));
 
+  cmd_vel_in_timeout_ = this->declare_parameter("cmd_vel_in_timeout", 0.5);
+
+  twist_watchdog_timer_ =
+    this->create_wall_timer(
+    std::chrono::milliseconds((int)std::round(1000.0 * cmd_vel_in_timeout_)),
+    std::bind(&EmergencyStopMonitor::twist_watchdog_callback, this));
+
   twist_subscriber_ = this->create_subscription<geometry_msgs::msg::Twist>(
     "/cmd_vel_in", 10, std::bind(&EmergencyStopMonitor::twist_callback, this, _1));
   twist_publisher_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel_out", 10);
@@ -59,11 +66,31 @@ void EmergencyStopMonitor::emergency_stop_callback(
 
 void EmergencyStopMonitor::twist_callback(const geometry_msgs::msg::Twist::SharedPtr twist_msg)
 {
+  if (twist_watchdog_timer_->is_canceled()) {
+    RCLCPP_WARN(get_logger(), "Receiving msgs from cmd_vel_in topic.");
+  }
+  twist_watchdog_timer_->reset();
+
   if (emergency_stop_value_) {
     twist_msg->linear.x = 0.0;
     twist_msg->angular.z = 0.0;
   }
   twist_publisher_->publish(*twist_msg);
+}
+
+void EmergencyStopMonitor::twist_watchdog_callback()
+{
+  RCLCPP_WARN(
+    get_logger(),
+    "cmd_vel_in topic has timedout for %.2f seconds. Publishing zero velocity on cmd_vel_out topic.",
+    cmd_vel_in_timeout_);
+
+  auto twist_msg = geometry_msgs::msg::Twist();
+  twist_msg.linear.x = 0.0;
+  twist_msg.angular.z = 0.0;
+  twist_publisher_->publish(twist_msg);
+
+  twist_watchdog_timer_->cancel();
 }
 }  // namespace waywiser_twist_safety
 


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

If the cmd_vel_in topic stops publishing msgs with a non-zero twist as its last msg, the rover continues to act on the last msg as there is no watchdog in waywise_rover node. 

* **What is the new behavior (if this is a feature change)?**

A watchdog timer is implemented in emergency_stop_monitor that publish a zero velocity twist msg if cmd_vel_in topic time outs. This calls the twist_callback function in waywise_rover which updates desired speed and steering in mCarMovementController.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:


