### PR TITLE
Fix/use_sim_time

### DIFF
--- a/waywiser/launch/gazebo_slam.launch.py
+++ b/waywiser/launch/gazebo_slam.launch.py
@@ -12,6 +12,7 @@ def generate_launch_description():
     waywiser_gazebo_dir = get_package_share_directory('waywiser_gazebo')
     waywiser_twist_safety_dir = get_package_share_directory('waywiser_twist_safety')
     waywiser_slam_dir = get_package_share_directory('waywiser_slam')
+    waywiser_rviz2_dir = get_package_share_directory('waywiser_rviz2')
 
     # args that can be set from the command line or a default will be used
     use_sim_time_la = DeclareLaunchArgument(
@@ -26,6 +27,11 @@ def generate_launch_description():
         'enable_collision_monitor',
         default_value='True',
         description='Use Nav2 collision monitoring',
+    )
+    rviz_config_la = DeclareLaunchArgument(
+        'rviz_config',
+        default_value=os.path.join(waywiser_rviz2_dir, 'rviz/map_reference_frame_slam.rviz'),
+        description='Full path of rviz display config file or path to their directory',
     )
 
     # include launch files
@@ -76,6 +82,23 @@ def generate_launch_description():
         }.items(),
     )
 
+    # include launch files
+    teleop_rviz2 = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    get_package_share_directory('waywiser'),
+                    'launch',
+                    'teleop_rviz2.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'rviz_config': LaunchConfiguration('rviz_config'),
+        }.items(),
+    )
+
     # create launch description
     ld = LaunchDescription()
 
@@ -83,10 +106,12 @@ def generate_launch_description():
     ld.add_action(use_sim_time_la)
     ld.add_action(gazebo_world_la)
     ld.add_action(enable_collision_monitor_la)
+    ld.add_action(rviz_config_la)
 
     # start nodes
     ld.add_action(gazebo)
     ld.add_action(twist_safety)
     ld.add_action(slam)
+    ld.add_action(teleop_rviz2)
 
     return ld

--- a/waywiser/launch/gazebo_slam_nav2.launch.py
+++ b/waywiser/launch/gazebo_slam_nav2.launch.py
@@ -13,6 +13,7 @@ def generate_launch_description():
     waywiser_twist_safety_dir = get_package_share_directory('waywiser_twist_safety')
     waywiser_slam_dir = get_package_share_directory('waywiser_slam')
     waywiser_nav2_dir = get_package_share_directory('waywiser_nav2')
+    waywiser_rviz2_dir = get_package_share_directory('waywiser_rviz2')
 
     # args that can be set from the command line or a default will be used
     use_sim_time_la = DeclareLaunchArgument(
@@ -27,6 +28,11 @@ def generate_launch_description():
         'enable_collision_monitor',
         default_value='True',
         description='Use Nav2 collision monitoring',
+    )
+    rviz_config_la = DeclareLaunchArgument(
+        'rviz_config',
+        default_value=os.path.join(waywiser_rviz2_dir, 'rviz/map_reference_frame_nav2.rviz'),
+        description='Full path of rviz display config file or path to their directory',
     )
 
     # include launch files
@@ -92,6 +98,23 @@ def generate_launch_description():
         }.items(),
     )
 
+    # include launch files
+    teleop_rviz2 = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    get_package_share_directory('waywiser'),
+                    'launch',
+                    'teleop_rviz2.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'rviz_config': LaunchConfiguration('rviz_config'),
+        }.items(),
+    )
+
     # create launch description
     ld = LaunchDescription()
 
@@ -99,11 +122,13 @@ def generate_launch_description():
     ld.add_action(use_sim_time_la)
     ld.add_action(gazebo_world_la)
     ld.add_action(enable_collision_monitor_la)
+    ld.add_action(rviz_config_la)
 
     # start nodes
     ld.add_action(gazebo)
     ld.add_action(twist_safety)
     ld.add_action(slam)
     ld.add_action(nav2)
+    ld.add_action(teleop_rviz2)
 
     return ld

--- a/waywiser/launch/teleop_rviz2.launch.py
+++ b/waywiser/launch/teleop_rviz2.launch.py
@@ -14,7 +14,7 @@ def generate_launch_description():
 
     # args that can be set from the command line or a default will be used
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
     rviz_config_la = DeclareLaunchArgument(
         'rviz_config',

--- a/waywiser/launch/teleop_rviz2.launch.py
+++ b/waywiser/launch/teleop_rviz2.launch.py
@@ -18,7 +18,7 @@ def generate_launch_description():
     )
     rviz_config_la = DeclareLaunchArgument(
         'rviz_config',
-        default_value=os.path.join(waywiser_rviz2_dir, 'rviz/map_reference_frame_nav2.rviz'),
+        default_value='',
         description='Full path of rviz display config file or path to their directory',
     )
 

--- a/waywiser_hwbringup/README.md
+++ b/waywiser_hwbringup/README.md
@@ -18,10 +18,10 @@
 
     ros2 launch waywiser_hwbringup waywise_autopilot.launch.py
     ros2 launch waywiser_hwbringup waywise_autopilot.launch.py rover_config:=./src/WayWiseR/waywiser_hwbringup/config/rover.yaml
-    ros2 launch waywiser_hwbringup waywise_autopilot.launch.py use_sim_time:=false
+    ros2 launch waywiser_hwbringup waywise_autopilot.launch.py use_sim_time:=true
 
     ros2 launch waywiser_hwbringup realsense_d435i.launch.py
-    ros2 launch waywiser_hwbringup realsense_d435i.launch.py use_sim_time:=false
+    ros2 launch waywiser_hwbringup realsense_d435i.launch.py use_sim_time:=true
     ros2 launch waywiser_hwbringup realsense_d435i.launch.py log_level:=debug
     ros2 launch waywiser_hwbringup realsense_d435i.launch.py namespace:=/sensors/drone/camera
     ros2 launch waywiser_hwbringup realsense_d435i.launch.py container:=/sensors/camera/camera_container

--- a/waywiser_hwbringup/launch/waywise_autopilot.launch.py
+++ b/waywiser_hwbringup/launch/waywise_autopilot.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
     )
 
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     # start nodes and use args to set parameters

--- a/waywiser_nav2/README.md
+++ b/waywiser_nav2/README.md
@@ -1,6 +1,6 @@
 ## Examples
 
     ros2 launch waywiser_nav2 nav2_bringup_all.launch.py
-    ros2 launch waywiser_nav2 nav2_bringup_all.launch.py use_sim_time:=false
+    ros2 launch waywiser_nav2 nav2_bringup_all.launch.py use_sim_time:=true
     ros2 launch waywiser_nav2 nav2_bringup_all.launch.py params_file:=./src/WayWiseR/waywiser_nav2/config/nav2.yaml
     ros2 launch waywiser_nav2 nav2_bringup_all.launch.py use_composition:=true

--- a/waywiser_nav2/launch/nav2_bringup_all.launch.py
+++ b/waywiser_nav2/launch/nav2_bringup_all.launch.py
@@ -88,7 +88,7 @@ def generate_launch_description():
     )
 
     declare_use_sim_time_cmd = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation (Gazebo) clock if true'
+        'use_sim_time', default_value='False', description='Use simulation (Gazebo) clock if true'
     )
 
     declare_params_file_cmd = DeclareLaunchArgument(

--- a/waywiser_nav2/launch/nav2_path_planner.launch.py
+++ b/waywiser_nav2/launch/nav2_path_planner.launch.py
@@ -22,7 +22,7 @@ def generate_launch_description():
     )
 
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     enable_smoother_server_la = DeclareLaunchArgument(

--- a/waywiser_nav2/launch/nav2_waypoint_navigator.launch.py
+++ b/waywiser_nav2/launch/nav2_waypoint_navigator.launch.py
@@ -21,7 +21,7 @@ def generate_launch_description():
     )
 
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     # start nodes and use args to set parameters

--- a/waywiser_perception/README.md
+++ b/waywiser_perception/README.md
@@ -41,6 +41,6 @@
 ## Examples
 
     ros2 launch waywiser_perception yolov8.launch.py
-    ros2 launch waywiser_perception yolov8.launch.py use_sim_time:=false
+    ros2 launch waywiser_perception yolov8.launch.py use_sim_time:=true
     ros2 launch waywiser_perception yolov8.launch.py yolov8_config:=./src/WayWiseR/waywiser_perception/config/yolov8.yaml
     ros2 launch waywiser_perception yolov8.launch.py yolov8_config:=config_file_of_your_choice

--- a/waywiser_perception/launch/yolov8.launch.py
+++ b/waywiser_perception/launch/yolov8.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
     )
 
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     # include launch files

--- a/waywiser_rviz2/README.md
+++ b/waywiser_rviz2/README.md
@@ -1,6 +1,6 @@
 ## Examples
 
     ros2 launch waywiser_rviz2 rviz.launch.py
-    ros2 launch waywiser_rviz2 rviz.launch.py use_sim_time:=false
+    ros2 launch waywiser_rviz2 rviz.launch.py use_sim_time:=true
     ros2 launch waywiser_rviz2 rviz.launch.py rviz_config:=./src/WayWiseR/waywiser_rviz2/rviz/
     ros2 launch waywiser_rviz2 rviz.launch.py rviz_config:=./src/WayWiseR/waywiser_rviz2/rviz/odom_reference_frame.rviz

--- a/waywiser_rviz2/launch/rviz.launch.py
+++ b/waywiser_rviz2/launch/rviz.launch.py
@@ -17,7 +17,7 @@ def generate_launch_description():
     )
     use_sim_time_la = DeclareLaunchArgument(
         'use_sim_time',
-        default_value='True',
+        default_value='False',
         description='Use simulation/Gazebo clock',
     )
 

--- a/waywiser_slam/README.md
+++ b/waywiser_slam/README.md
@@ -1,5 +1,5 @@
 ## Examples
 
     ros2 launch waywiser_slam slam.launch.py
-    ros2 launch waywiser_slam slam.launch.py use_sim_time:=false
+    ros2 launch waywiser_slam slam.launch.py use_sim_time:=true
     ros2 launch waywiser_slam slam.launch.py slam_config:=$(pwd)/src/WayWiseR/waywiser_slam/config/slam.yaml

--- a/waywiser_slam/launch/slam.launch.py
+++ b/waywiser_slam/launch/slam.launch.py
@@ -1,7 +1,6 @@
 import os
 
 from ament_index_python import get_package_share_directory
-
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
@@ -18,7 +17,7 @@ def generate_launch_description():
         description='Full path to params file for slam toolbox',
     )
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     # start nodes and use args to set parameters

--- a/waywiser_teleop/README.md
+++ b/waywiser_teleop/README.md
@@ -1,4 +1,5 @@
- ## Examples
- 
+## Examples
+
     ros2 launch waywiser_teleop teleop.launch.py
+    ros2 launch waywiser_teleop teleop.launch.py use_sim_time:=true
     ros2 launch waywiser_teleop teleop.launch.py teleop_config:=$(pwd)/src/WayWiseR/waywiser_teleop/config/teleop.yaml

--- a/waywiser_teleop/launch/teleop.launch.py
+++ b/waywiser_teleop/launch/teleop.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
     )
 
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     # start nodes and use args to set parameters

--- a/waywiser_twist_safety/README.md
+++ b/waywiser_twist_safety/README.md
@@ -1,7 +1,7 @@
 ## Examples
 
     ros2 launch waywiser_twist_safety twist_safety.launch.py
-    ros2 launch waywiser_twist_safety twist_safety.launch.py use_sim_time:=false
+    ros2 launch waywiser_twist_safety twist_safety.launch.py use_sim_time:=true
     ros2 launch waywiser_twist_safety twist_safety.launch.py enable_collision_monitor:=true
     ros2 launch waywiser_twist_safety twist_safety.launch.py twist_safety_config:=./src/WayWiseR/waywiser_twist_safety/config/twist_safety.yaml
 

--- a/waywiser_twist_safety/launch/twist_safety.launch.py
+++ b/waywiser_twist_safety/launch/twist_safety.launch.py
@@ -20,7 +20,7 @@ def generate_launch_description():
     )
 
     use_sim_time_la = DeclareLaunchArgument(
-        'use_sim_time', default_value='True', description='Use simulation/Gazebo clock'
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
     )
 
     enable_collision_monitor_la = DeclareLaunchArgument(


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  Bug fix

* **What is the current behavior?** (You can also link to an open issue here)

  Currently, we set the 'use_sim_time' parameter as 'True' by default in all launch files. Because of this, the nodes wait for a simulator clock after the launch. If the parameter is not manually set to 'false' when launching, for example, slam.launch.py with a physical rover, it will fail to start. IMO the default should be set to 'False' and it can be set to True manually only when using a simulator.

* **What is the new behavior (if this is a feature change)?**

  'use_sim_time' is set to 'False' by default in the launch files except those launch files that start with gazebo

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  No


