### PR TITLE
Feature/sync emergency stop state across nodes

### DIFF
--- a/waywiser_perception/CMakeLists.txt
+++ b/waywiser_perception/CMakeLists.txt
@@ -56,7 +56,9 @@ install(DIRECTORY launch config
   DESTINATION share/${PROJECT_NAME}
 )
 
-ament_python_install_package(py_scripts)
+ament_python_install_package(${PROJECT_NAME}_py
+  PACKAGE_DIR py_scripts
+)
 
 install(PROGRAMS
   py_scripts/yolov8_node.py

--- a/waywiser_teleop/CMakeLists.txt
+++ b/waywiser_teleop/CMakeLists.txt
@@ -27,7 +27,9 @@ install(TARGETS twist_angular_correction RUNTIME DESTINATION lib/${PROJECT_NAME}
 
 install(DIRECTORY launch config DESTINATION share/${PROJECT_NAME})
 
-ament_python_install_package(py_scripts)
+ament_python_install_package(${PROJECT_NAME}_py
+  PACKAGE_DIR py_scripts
+)
 
 install(PROGRAMS
   py_scripts/twist_keyboard.py

--- a/waywiser_teleop/CMakeLists.txt
+++ b/waywiser_teleop/CMakeLists.txt
@@ -15,9 +15,13 @@ find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(ament_cmake_python REQUIRED)
 find_package(rclpy REQUIRED)
+find_package(waywiser_twist_safety REQUIRED)
 
 add_executable(joy_emergency_stop src/joy_emergency_stop.cpp)
-ament_target_dependencies(joy_emergency_stop rclcpp sensor_msgs std_msgs)
+ament_target_dependencies(joy_emergency_stop rclcpp sensor_msgs std_msgs waywiser_twist_safety)
+target_include_directories(joy_emergency_stop PRIVATE
+  ${waywiser_twist_safety_INCLUDE_DIRS}
+)
 
 add_executable(twist_angular_correction src/twist_angular_correction.cpp)
 ament_target_dependencies(twist_angular_correction geometry_msgs rclcpp sensor_msgs std_msgs)

--- a/waywiser_teleop/config/teleop.yaml
+++ b/waywiser_teleop/config/teleop.yaml
@@ -26,7 +26,7 @@ teleop_twist_joy:
 
 twist_keyboard:
   ros__parameters:
-    enable: false
+    enable: true
     max_linear_speed: 2.0
     max_angular_speed: 2.0
     startup_linear_speed: 0.5

--- a/waywiser_teleop/launch/teleop.launch.py
+++ b/waywiser_teleop/launch/teleop.launch.py
@@ -3,6 +3,7 @@ import os
 from ament_index_python import get_package_share_directory
 from launch import LaunchDescription
 from launch.actions import DeclareLaunchArgument
+from launch.actions import LogInfo
 from launch.actions import OpaqueFunction
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
@@ -115,17 +116,23 @@ def twist_keyboard_conditional_launch(context):
             twist_keyboard_params = config_data['twist_keyboard']['ros__parameters']
             enable_twist_keyboard = twist_keyboard_params['enable']
             if enable_twist_keyboard:
-                twist_keyboard_node = Node(
-                    package='waywiser_teleop',
-                    executable='twist_keyboard.py',
-                    name='twist_keyboard',
-                    output='screen',
-                    parameters=[
-                        twist_keyboard_params,
-                        {'use_sim_time': LaunchConfiguration('use_sim_time')},
-                    ],
-                    remappings={('/cmd_vel', '/key_vel')},
-                )
-                return [twist_keyboard_node]
+                if 'DISPLAY' in os.environ:
+                    twist_keyboard_node = Node(
+                        package='waywiser_teleop',
+                        executable='twist_keyboard.py',
+                        name='twist_keyboard',
+                        output='screen',
+                        parameters=[
+                            twist_keyboard_params,
+                            {'use_sim_time': LaunchConfiguration('use_sim_time')},
+                        ],
+                        remappings={('/cmd_vel', '/key_vel')},
+                    )
+                    return [twist_keyboard_node]
+                else:
+                    log_no_display = LogInfo(
+                        msg='No GUI display detected. twist_keyboard_node will not be launched.'
+                    )
+                    return [log_no_display]
 
     return []

--- a/waywiser_teleop/package.xml
+++ b/waywiser_teleop/package.xml
@@ -29,6 +29,7 @@
   <depend>teleop_twist_joy</depend>
   <depend>twist_mux</depend>
   <depend>rclpy</depend>
+  <depend>waywiser_twist_safety</depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/waywiser_teleop/package.xml
+++ b/waywiser_teleop/package.xml
@@ -15,6 +15,7 @@
   <url type="website">http://wiki.ros.org/twist_mux</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_python</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>

--- a/waywiser_teleop/py_scripts/twist_keyboard.py
+++ b/waywiser_teleop/py_scripts/twist_keyboard.py
@@ -4,7 +4,12 @@ from geometry_msgs.msg import Twist
 import pygame
 import rclpy
 from rclpy.node import Node
-from std_msgs.msg import Bool
+from rclpy.qos import QoSDurabilityPolicy
+from rclpy.qos import QoSHistoryPolicy
+from rclpy.qos import QoSProfile
+from rclpy.qos import QoSReliabilityPolicy
+
+from waywiser_twist_safety.msg import EmergencyStopState
 
 
 class TwistKeyboard(Node):
@@ -13,11 +18,27 @@ class TwistKeyboard(Node):
     def __init__(self):
         super().__init__('twist_keyboard')
         self.twist_publisher = self.create_publisher(Twist, 'cmd_vel', 10)
-        self.emergency_stop_publisher = self.create_publisher(Bool, 'emergency_stop', 10)
+        self.emergency_stop_request_publisher = self.create_publisher(
+            EmergencyStopState, '/emergency_stop/target_state', 10
+        )
 
-        # Initialize emergency_stop_msg
-        self.emergency_stop_msg = Bool()
-        self.emergency_stop_msg.data = False
+        self.emergency_stop_state_subscriber = self.create_subscription(
+            EmergencyStopState,
+            '/emergency_stop/current_state',
+            self.emergency_stop_state_subscriber_callback,
+            QoSProfile(
+                reliability=QoSReliabilityPolicy.BEST_EFFORT,
+                history=QoSHistoryPolicy.KEEP_LAST,
+                durability=QoSDurabilityPolicy.VOLATILE,
+                depth=1,
+            ),
+        )
+        self.emergency_stop_current_state = EmergencyStopState.UNKNOWN
+
+        # Initialize emergency_stop_target_state_msg
+        self.emergency_stop_target_state_msg = EmergencyStopState()
+        self.emergency_stop_target_state_msg.sender_id = 'twist_keyboard'
+        self.emergency_stop_target_state_msg.state = EmergencyStopState.ACTIVE
 
         # Set up keybindings
         self.forward_key = pygame.K_w
@@ -90,6 +111,9 @@ class TwistKeyboard(Node):
         pygame.event.set_allowed(None)  # Disable all events
         pygame.event.set_allowed(pygame.QUIT)  # Enable quit event
 
+    def emergency_stop_state_subscriber_callback(self, emergency_stop_current_state):
+        self.emergency_stop_current_state = emergency_stop_current_state.state
+
     def capture_pressed_keys(self):
         keys = pygame.key.get_pressed()
 
@@ -111,9 +135,9 @@ class TwistKeyboard(Node):
 
         if keys:
             # Process emergency stop set/clear event
-            emergency_stop_event_registered = self.process_emergency_stop_keys(keys)
+            emergency_stop_set_event_registered = self.process_emergency_stop_keys(keys)
 
-            if not emergency_stop_event_registered:
+            if not emergency_stop_set_event_registered:
                 # Check if the key associated with increasing linear speed is pressed
                 if keys[self.increase_linear_speed_key]:
                     # Increase linear speed by 10%
@@ -147,7 +171,7 @@ class TwistKeyboard(Node):
 
         if keys:
             # Process emergency stop set/clear event
-            self.process_emergency_stop_keys(keys)
+            emergency_stop_set_event_registered = self.process_emergency_stop_keys(keys)
 
             # Check if any of the actuation keys are pressed now
             is_actuation_requested_now = any(keys[i] for i in self.actuation_keys)
@@ -157,7 +181,7 @@ class TwistKeyboard(Node):
                     # Publish zero velocity twist message
                     self.twist_publisher.publish(twist)
 
-                elif not self.emergency_stop_msg.data:
+                elif not emergency_stop_set_event_registered:
                     # Process actuation keys
                     if not keys[self.stop_key]:
                         if keys[self.forward_key]:
@@ -191,18 +215,13 @@ class TwistKeyboard(Node):
         # Check if emergency stop key is pressed
         if emergency_stop_event_registered:
             if keys[pygame.K_LSHIFT] or keys[pygame.K_RSHIFT]:
-                if self.emergency_stop_msg.data:
-                    # Clear emergency stop signal
-                    self.emergency_stop_msg.data = False
-                    self.get_logger().warn('Emergency stop CLEARED from keyboard.')
+                emergency_stop_event_registered = False
+                self.emergency_stop_target_state_msg.state = EmergencyStopState.CLEAR
             else:
-                if not self.emergency_stop_msg.data:
-                    # Set emergency stop signal
-                    self.emergency_stop_msg.data = True
-                    self.get_logger().warn('Emergency stop ACTIVATED from keyboard.')
-                    self.twist_publisher.publish(Twist())
+                self.emergency_stop_target_state_msg.state = EmergencyStopState.ACTIVE
 
-            self.emergency_stop_publisher.publish(self.emergency_stop_msg)
+            self.emergency_stop_target_state_msg.stamp = self.get_clock().now().to_msg()
+            self.emergency_stop_request_publisher.publish(self.emergency_stop_target_state_msg)
 
         return emergency_stop_event_registered
 
@@ -224,9 +243,16 @@ class TwistKeyboard(Node):
             '************************** Status *********************************\n\n'
             f'Configured speeds: Linear - {self.linear_speed:.2f}; Angular - {self.angular_speed:.2f}\n\n'  # noqa
             f'Publishing speeds: Linear - {twist.linear.x:.2f}; Angular - {twist.angular.z:.2f}\n\n'  # noqa
-            f'Emergency stop: {"ACTIVATED" if self.emergency_stop_msg.data else "CLEARED"}\n\n'
-            '*********************************************************************\n\n'
         )
+
+        if self.emergency_stop_current_state == EmergencyStopState.ACTIVE:
+            text = text + 'Emergency stop state: "ACTIVE"\n\n'
+        elif self.emergency_stop_current_state == EmergencyStopState.CLEAR:
+            text = text + 'Emergency stop state: "CLEAR"\n\n'
+        else:
+            text = text + 'Emergency stop state: "UNKNOWN"\n\n'
+
+        text = text + '*********************************************************************\n\n'
 
         self.blit_text(text, (20, 20))
 

--- a/waywiser_teleop/src/joy_emergency_stop.cpp
+++ b/waywiser_teleop/src/joy_emergency_stop.cpp
@@ -1,13 +1,13 @@
-#include <chrono>
-#include <functional>
 #include <memory>
 #include <string>
 
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
 #include "std_msgs/msg/bool.hpp"
+#include "waywiser_twist_safety/msg/emergency_stop_state.hpp"
 
-using std::placeholders::_1;
+using namespace std::placeholders;
+using namespace waywiser_twist_safety::msg;
 
 class JoyEmergencyStop : public rclcpp::Node
 {
@@ -21,15 +21,19 @@ public:
       "emergency_stop_clear_joy_button_index", 7);
     joy_emergency_stop_timeout_ = this->declare_parameter("joy_emergency_stop_timeout", 1.0);
 
-    emergency_stop_publisher_ = this->create_publisher<std_msgs::msg::Bool>("emergency_stop", 10);
+    emergency_stop_request_publisher_ = this->create_publisher<EmergencyStopState>(
+      "/emergency_stop/target_state", 10);
+
     joy_subscriber_ = this->create_subscription<sensor_msgs::msg::Joy>(
-      "/joy", 10, std::bind(&JoyEmergencyStop::joy_callback, this, std::placeholders::_1));
+      "/joy", 10, std::bind(&JoyEmergencyStop::joy_callback, this, _1));
 
     joy_watchdog_timer_ =
       this->create_wall_timer(
       std::chrono::milliseconds((int)std::round(1000.0 * joy_emergency_stop_timeout_)),
       std::bind(&JoyEmergencyStop::joy_watchdog_callback, this));
-    emergency_stop_msg_.data = false;
+
+    emergency_stop_target_state_msg_.sender_id = "twist_joy";
+    emergency_stop_target_state_msg_.state = EmergencyStopState::ACTIVE;
 
     RCLCPP_INFO(
       get_logger(),
@@ -42,43 +46,26 @@ private:
   void joy_callback(const sensor_msgs::msg::Joy::SharedPtr joy_msg)
   {
     if (joy_watchdog_timer_->is_canceled()) {
-      if (emergency_stop_msg_.data) {
-        RCLCPP_WARN(
-          get_logger(),
-          "Receiving messages from /joy topic now, "
-          "but emergency_stop is ACTIVATED.");
-      } else {
-        RCLCPP_WARN(
-          get_logger(),
-          "Receiving messages from /joy topic now. "
-          "Monitoring emergency_stop button.");
-      }
+      RCLCPP_WARN(
+        get_logger(),
+        "Receiving messages from /joy topic now. "
+        "Monitoring emergency_stop button.");
     }
     joy_watchdog_timer_->reset();
 
     if (joy_msg->buttons[emergency_stop_set_joy_button_index_] == 1) {
-      if (!emergency_stop_msg_.data) {
-        emergency_stop_msg_.data = true;
-        emergency_stop_publisher_->publish(emergency_stop_msg_);
-        RCLCPP_WARN(get_logger(), "emergency_stop ACTIVATED from /joy topic.");
-      } else {
-        emergency_stop_publisher_->publish(emergency_stop_msg_);
-      }
+      emergency_stop_target_state_msg_.state = EmergencyStopState::ACTIVE;
+      emergency_stop_request_publisher_->publish(emergency_stop_target_state_msg_);
     } else if (joy_msg->buttons[emergency_stop_clear_joy_button_index_] == 1) {
-      if (emergency_stop_msg_.data) {
-        emergency_stop_msg_.data = false;
-        emergency_stop_publisher_->publish(emergency_stop_msg_);
-        RCLCPP_WARN(get_logger(), "emergency_stop CLEARED from /joy topic.");
-      } else {
-        emergency_stop_publisher_->publish(emergency_stop_msg_);
-      }
+      emergency_stop_target_state_msg_.state = EmergencyStopState::CLEAR;
+      emergency_stop_request_publisher_->publish(emergency_stop_target_state_msg_);
     }
   }
 
   void joy_watchdog_callback()
   {
-    emergency_stop_msg_.data = true;
-    emergency_stop_publisher_->publish(emergency_stop_msg_);
+    emergency_stop_target_state_msg_.state = EmergencyStopState::ACTIVE;
+    emergency_stop_request_publisher_->publish(emergency_stop_target_state_msg_);
     RCLCPP_WARN(
       get_logger(),
       "/joy topic has stopped publishing for %.2f seconds. "
@@ -89,7 +76,7 @@ private:
   }
 
   // Publishers and subscribers
-  rclcpp::Publisher<std_msgs::msg::Bool>::SharedPtr emergency_stop_publisher_;
+  rclcpp::Publisher<EmergencyStopState>::SharedPtr emergency_stop_request_publisher_;
   rclcpp::Subscription<sensor_msgs::msg::Joy>::SharedPtr joy_subscriber_;
 
   // Timer
@@ -99,7 +86,7 @@ private:
   int emergency_stop_set_joy_button_index_;
   int emergency_stop_clear_joy_button_index_;
   float joy_emergency_stop_timeout_;
-  std_msgs::msg::Bool emergency_stop_msg_;
+  EmergencyStopState emergency_stop_target_state_msg_;
 };
 
 int main(int argc, char * argv[])

--- a/waywiser_twist_safety/CMakeLists.txt
+++ b/waywiser_twist_safety/CMakeLists.txt
@@ -12,12 +12,32 @@ find_package(geometry_msgs REQUIRED)
 find_package(std_msgs REQUIRED)
 find_package(sensor_msgs REQUIRED)
 find_package(rclcpp_components REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
 
 include_directories(include)
+
+# Generate msgs
+set(ROSIDL_FILES)
+
+file(GLOB MSG_FILES "${CMAKE_CURRENT_SOURCE_DIR}/msg/*.msg")
+
+foreach(MSG_FILE ${MSG_FILES})
+  get_filename_component(MSG_NAME ${MSG_FILE} NAME)
+  list(APPEND ROSIDL_FILES msg/${MSG_NAME})
+endforeach()
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  ${ROSIDL_FILES}
+  DEPENDENCIES std_msgs builtin_interfaces
+)
+
+rosidl_get_typesupport_target(cpp_typesupport_target
+  ${PROJECT_NAME} rosidl_typesupport_cpp)
 
 add_library(emergency_stop_monitor_core SHARED src/rclcpp_components/emergency_stop_monitor_core.cpp)
 ament_target_dependencies(emergency_stop_monitor_core geometry_msgs rclcpp rclcpp_components sensor_msgs std_msgs)
 rclcpp_components_register_nodes(emergency_stop_monitor_core waywiser_twist_safety::EmergencyStopMonitor)
+target_link_libraries(emergency_stop_monitor_core "${cpp_typesupport_target}")
 
 add_executable(emergency_stop_monitor src/emergency_stop_monitor.cpp)
 target_link_libraries(emergency_stop_monitor emergency_stop_monitor_core)
@@ -30,9 +50,12 @@ install(
 
 install(TARGETS emergency_stop_monitor RUNTIME DESTINATION lib/${PROJECT_NAME})
 
-install(DIRECTORY include/ DESTINATION include/)
+install(DIRECTORY include/ DESTINATION include/${PROJECT_NAME})
 
 install(DIRECTORY launch config DESTINATION share/${PROJECT_NAME})
+
+ament_export_dependencies(rosidl_default_runtime)
+ament_export_include_directories(include)
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)

--- a/waywiser_twist_safety/README.md
+++ b/waywiser_twist_safety/README.md
@@ -10,20 +10,20 @@
 - To set emergency_stop:
 
   ```
-  ros2 topic pub --once /emergency_stop std_msgs/msg/Bool "data: true"
+  ros2 topic pub --once /emergency_stop/target_state waywiser_twist_safety/msg/EmergencyStopState "{sender_id : 'command_line' , state : 2}"
   ```
 
 - To clear emergency_stop
 
   ```
-  ros2 topic pub --once /emergency_stop std_msgs/msg/Bool "data: false"
+  ros2 topic pub --once /emergency_stop/target_state waywiser_twist_safety/msg/EmergencyStopState "{sender_id : 'command_line' , state : 1}"
   ```
 
 ## Nodes launched by twist_safety.launch.py
 
 1. **onboard_twist_mux**: node that subscribes to topics configured in twist_safety_config file, e.g., teleop_mux_vel, waywise_vel etc., and publishes to onboard_mux_vel by multiplexing between sunscribed topics according to their priorities.
 2. **collision_monitor**: node is launched when "enable_collision_monitor" launch argument is set to true. It performs several collision avoidance related tasks using incoming data from the lidar and/or depth camera sensors and prevents potential collisions by reducing the linear speed and even setting it to zero to stop the vehicle.
-3. **emergency_stop_monitor**: Upon receiving a boolean 'true' data on the "/emergency_stop" topic, it suspends the input twist commands and publishes a zero-velocity twist command on its output topic. When a boolean 'false' data is received on the "/emergency_stop" topic, the emergency stop is deactivated, allowing the commands to pass through from the input to the output twist topics.
+3. **emergency_stop_monitor**: Upon receiving a 'waywiser_twist_safety/msg/EmergencyStopState' type message with the state field set to '2' on the "/emergency_stop/target_state" topic, it suspends the input twist commands and publishes a zero-velocity twist command on its output topic. Instead, when the state field is set to '1', the emergency stop is deactivated, allowing the commands to pass through from the input to the output twist topics.
 
 A typical node graph would look as follows:
-![collision_monitor](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR/assets/58977950/620268c8-0dbb-4b35-8ac6-01fc6797b0b3)
+![collision_monitor](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR/assets/58977950/263c7c78-2cd9-4a8e-a50e-f1ab23c32e6e)

--- a/waywiser_twist_safety/config/twist_safety.yaml
+++ b/waywiser_twist_safety/config/twist_safety.yaml
@@ -2,6 +2,7 @@ emergency_stop_monitor:
   ros__parameters:
     start_with_emergency_stop: true
     cmd_vel_in_timeout: 0.5
+    emergency_stop_state_publish_rate: 10
 
 onboard_twist_mux:
   ros__parameters:

--- a/waywiser_twist_safety/include/emergency_stop_monitor.hpp
+++ b/waywiser_twist_safety/include/emergency_stop_monitor.hpp
@@ -2,17 +2,18 @@
 #define WAYWISER_TWIST_SAFETY_EMERGENCY_STOP_MONITOR_HPP_
 
 #include <chrono>
-#include <cmath>
 #include <memory>
-#include <vector>
 
 #include "geometry_msgs/msg/twist.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "sensor_msgs/msg/joy.hpp"
 #include "std_msgs/msg/bool.hpp"
 
-using std::placeholders::_1;
+#include "waywiser_twist_safety/msg/emergency_stop_state.hpp"
+
+using namespace std::placeholders;
 using namespace std::chrono;
+using namespace waywiser_twist_safety::msg;
 
 namespace waywiser_twist_safety
 {
@@ -22,19 +23,28 @@ public:
   explicit EmergencyStopMonitor(const rclcpp::NodeOptions & options = rclcpp::NodeOptions());
 
 private:
-  void emergency_stop_callback(const std_msgs::msg::Bool::SharedPtr emergency_stop_msg);
+  bool is_emergency_stop_active()
+  {
+    return current_emergency_stop_state_msg.state == EmergencyStopState::ACTIVE;
+  }
+  void emergency_stop_target_state_callback(
+    const EmergencyStopState::SharedPtr emergency_stop_target_state_msg);
   void twist_callback(const geometry_msgs::msg::Twist::SharedPtr twist_msg);
   void twist_watchdog_callback();
+  void emergency_stop_state_publisher_timer_callback();
 
-  rclcpp::Subscription<std_msgs::msg::Bool>::SharedPtr emergency_stop_subscriber_;
+  rclcpp::Subscription<EmergencyStopState>::SharedPtr emergency_stop_target_state_subscriber_;
+  rclcpp::Publisher<EmergencyStopState>::SharedPtr emergency_stop_current_state_publisher_;
   rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_subscriber_;
   rclcpp::Publisher<geometry_msgs::msg::Twist>::SharedPtr twist_publisher_;
 
-  bool emergency_stop_value_;
+  EmergencyStopState current_emergency_stop_state_msg;
   float cmd_vel_in_timeout_;
+  int emergency_stop_state_publish_rate_;
 
   // Timer
   rclcpp::TimerBase::SharedPtr twist_watchdog_timer_;
+  rclcpp::TimerBase::SharedPtr emergency_stop_state_publisher_timer_;
 };
 }  // namespace waywiser_twist_safety
 #endif  // WAYWISER_TWIST_SAFETY_EMERGENCY_STOP_MONITOR_HPP_

--- a/waywiser_twist_safety/launch/twist_safety.launch.py
+++ b/waywiser_twist_safety/launch/twist_safety.launch.py
@@ -80,7 +80,7 @@ def conditional_launch_setup(context):
                         LaunchConfiguration('twist_safety_config'),
                         {'use_sim_time': LaunchConfiguration('use_sim_time')},
                     ],
-                    remappings={('/bond', '/bond_nav2')},
+                    remappings={('/bond', '/bond_collision_monitor')},
                 ),
                 Node(
                     package='nav2_lifecycle_manager',

--- a/waywiser_twist_safety/msg/EmergencyStopState.msg
+++ b/waywiser_twist_safety/msg/EmergencyStopState.msg
@@ -1,0 +1,9 @@
+# File: waywiser_twist_safety/msg/EmergencyStopState.msg
+
+uint8 UNKNOWN = 0
+uint8 CLEAR = 1
+uint8 ACTIVE = 2
+
+string sender_id
+builtin_interfaces/Time stamp
+uint8 state

--- a/waywiser_twist_safety/package.xml
+++ b/waywiser_twist_safety/package.xml
@@ -23,6 +23,7 @@
   <url type="website">https://github.com/ros-planning/navigation2/tree/humble/nav2_collision_monitor</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
@@ -34,6 +35,9 @@
   <depend>twist_mux</depend>
   <depend>nav2_collision_monitor</depend>
   <depend>nav2_lifecycle_manager</depend>
+
+  <exec_depend>rosidl_default_runtime</exec_depend>
+  <member_of_group>rosidl_interface_packages</member_of_group>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/waywiser_twist_safety/src/rclcpp_components/emergency_stop_monitor_core.cpp
+++ b/waywiser_twist_safety/src/rclcpp_components/emergency_stop_monitor_core.cpp
@@ -1,21 +1,35 @@
-#include <chrono>
-#include <cmath>
-#include <memory>
-#include <vector>
-
 #include "emergency_stop_monitor.hpp"
-
-using std::placeholders::_1;
 
 namespace waywiser_twist_safety
 {
 EmergencyStopMonitor::EmergencyStopMonitor(const rclcpp::NodeOptions & options)
 : Node("emergency_stop_monitor", options)
 {
-  emergency_stop_value_ = this->declare_parameter("start_with_emergency_stop", true);
+  current_emergency_stop_state_msg = EmergencyStopState();
+  current_emergency_stop_state_msg.sender_id = "emergency_stop_monitor";
 
-  emergency_stop_subscriber_ = this->create_subscription<std_msgs::msg::Bool>(
-    "/emergency_stop", 10, std::bind(&EmergencyStopMonitor::emergency_stop_callback, this, _1));
+  if (this->declare_parameter("start_with_emergency_stop", true)) {
+    current_emergency_stop_state_msg.state = EmergencyStopState::ACTIVE;
+    RCLCPP_WARN(get_logger(), "Emergency stop is ACTIVATED at startup.");
+  } else {
+    current_emergency_stop_state_msg.state = EmergencyStopState::CLEAR;
+    RCLCPP_WARN(get_logger(), "Emergency stop is CLEARED at startup.");
+  }
+
+  emergency_stop_target_state_subscriber_ = this->create_subscription<EmergencyStopState>(
+    "/emergency_stop/target_state", 10,
+    std::bind(&EmergencyStopMonitor::emergency_stop_target_state_callback, this, _1));
+
+  emergency_stop_current_state_publisher_ = this->create_publisher<EmergencyStopState>(
+    "/emergency_stop/current_state", 10);
+
+  emergency_stop_state_publish_rate_ = this->declare_parameter(
+    "emergency_stop_state_publish_rate", 10);
+
+  emergency_stop_state_publisher_timer_ =
+    this->create_wall_timer(
+    std::chrono::milliseconds((int)std::round(1000.0 / emergency_stop_state_publish_rate_)),
+    std::bind(&EmergencyStopMonitor::emergency_stop_state_publisher_timer_callback, this));
 
   cmd_vel_in_timeout_ = this->declare_parameter("cmd_vel_in_timeout", 0.5);
 
@@ -28,40 +42,47 @@ EmergencyStopMonitor::EmergencyStopMonitor(const rclcpp::NodeOptions & options)
     "/cmd_vel_in", 10, std::bind(&EmergencyStopMonitor::twist_callback, this, _1));
   twist_publisher_ = this->create_publisher<geometry_msgs::msg::Twist>("/cmd_vel_out", 10);
 
-  if (emergency_stop_value_) {
-    RCLCPP_WARN(get_logger(), "emergency_stop is ACTIVATED at startup.");
-  } else {
-    RCLCPP_WARN(get_logger(), "emergency_stop is CLEARED at startup.");
-  }
+  RCLCPP_INFO(
+    get_logger(),
+    "To activate emergency_stop from command line: ros2 topic pub --once "
+    "/emergency_stop/target_state waywiser_twist_safety/msg/EmergencyStopState \"{sender_id : 'command_line' , state : 2}\"");
+  RCLCPP_INFO(
+    get_logger(),
+    "To clear emergency_stop from command line: ros2 topic pub --once "
+    "/emergency_stop/target_state waywiser_twist_safety/msg/EmergencyStopState \"{sender_id : 'command_line' , state : 1}\"");
 
-  RCLCPP_INFO(
-    get_logger(),
-    "To activate emergency_stop from command line: ros2 topic pub "
-    "--once /emergency_stop std_msgs/msg/Bool \"data: true\"");
-  RCLCPP_INFO(
-    get_logger(),
-    "To clear emergency_stop from command line: ros2 topic pub "
-    "--once /emergency_stop std_msgs/msg/Bool \"data: false\"");
 }
 
-void EmergencyStopMonitor::emergency_stop_callback(
-  const std_msgs::msg::Bool::SharedPtr emergency_stop_msg)
+void EmergencyStopMonitor::emergency_stop_target_state_callback(
+  const EmergencyStopState::SharedPtr emergency_stop_target_state_msg)
 {
-  if (emergency_stop_msg->data) {
-    if (!emergency_stop_value_) {
-      emergency_stop_value_ = true;
-      RCLCPP_WARN(get_logger(), "emergency_stop ACTIVATED from /emergency_stop topic.");
+
+  if (emergency_stop_target_state_msg->state == EmergencyStopState::ACTIVE) {
+    if (!is_emergency_stop_active()) {
+      current_emergency_stop_state_msg.state = EmergencyStopState::ACTIVE;
+      RCLCPP_INFO(
+        get_logger(), "Emergency stop ACTIVATED by %s.",
+        emergency_stop_target_state_msg->sender_id.c_str());
+
       auto twist_msg = geometry_msgs::msg::Twist();
       twist_msg.linear.x = 0.0;
       twist_msg.angular.z = 0.0;
       twist_publisher_->publish(twist_msg);
     }
   } else {
-    if (emergency_stop_value_) {
-      emergency_stop_value_ = false;
-      RCLCPP_WARN(get_logger(), "emergency_stop CLEARED from /emergency_stop topic.");
+    if (is_emergency_stop_active()) {
+      current_emergency_stop_state_msg.state = EmergencyStopState::CLEAR;
+      RCLCPP_INFO(
+        get_logger(), "Emergency stop CLEARED by %s.",
+        emergency_stop_target_state_msg->sender_id.c_str());
     }
   }
+}
+
+void EmergencyStopMonitor::emergency_stop_state_publisher_timer_callback()
+{
+  current_emergency_stop_state_msg.stamp = this->now();
+  emergency_stop_current_state_publisher_->publish(current_emergency_stop_state_msg);
 }
 
 void EmergencyStopMonitor::twist_callback(const geometry_msgs::msg::Twist::SharedPtr twist_msg)
@@ -71,7 +92,7 @@ void EmergencyStopMonitor::twist_callback(const geometry_msgs::msg::Twist::Share
   }
   twist_watchdog_timer_->reset();
 
-  if (emergency_stop_value_) {
+  if (is_emergency_stop_active()) {
     twist_msg->linear.x = 0.0;
     twist_msg->angular.z = 0.0;
   }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

Emergency stop requesting nodes maintain their own internal state and publish target state as boolean msgs to emergency_stop_monitor node based on their internal states only if state change is necessary. They do not get any feedback from the emergency_stop_monitor. 

* **What is the new behavior (if this is a feature change)?**

Emergency stop requesting nodes (keyboard & joystick) do not have an internal state representing the emergency stop state on vehicle. They now send custom messages continuously to the emergency_stop_monitor node whenever the emergency stop button/key is pressed. In addition, the emergency_stop_monitor node sends the current state at a fixed rate via a separate topic.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:


