### PR TITLE
Waywise truck node for controlling miniature truck with trailer

### DIFF
--- a/waywiser/launch/truck_manual_control.launch.py
+++ b/waywiser/launch/truck_manual_control.launch.py
@@ -1,0 +1,106 @@
+import os
+
+from ament_index_python import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    waywiser_hwbringup_dir = get_package_share_directory('waywiser_hwbringup')
+    waywiser_twist_safety_dir = get_package_share_directory('waywiser_twist_safety')
+    waywiser_rviz2_dir = get_package_share_directory('waywiser_rviz2')
+    teleop_dir = get_package_share_directory('waywiser_teleop')
+
+    # args that can be set from the command line or a default will be used
+    use_sim_time_la = DeclareLaunchArgument(
+        'use_sim_time', default_value='False', description='Use simulation/Gazebo clock'
+    )
+    vehicle_config_la = DeclareLaunchArgument(
+        'vehicle_config',
+        default_value=os.path.join(waywiser_hwbringup_dir, 'config/truck_small_scale.yaml'),
+        description='Full path to params file of vehicle',
+    )
+    enable_collision_monitor_la = DeclareLaunchArgument(
+        'enable_collision_monitor',
+        default_value='False',
+        description='Use Nav2 collision monitoring',
+    )
+    rviz_config_la = DeclareLaunchArgument(
+        'rviz_config',
+        default_value=os.path.join(waywiser_rviz2_dir, 'rviz/odom_reference_frame_truck.rviz'),
+        description='Full path of rviz display config file or path to their directory',
+    )
+    teleop_config_la = DeclareLaunchArgument(
+        'teleop_config',
+        default_value=os.path.join(teleop_dir, 'config/teleop.yaml'),
+        description='Full path to params file',
+    )
+
+    # include launch files
+    truck = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    waywiser_hwbringup_dir,
+                    'launch',
+                    'waywise_truck.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'vehicle_config': LaunchConfiguration('vehicle_config'),
+        }.items(),
+    )
+
+    twist_safety = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    waywiser_twist_safety_dir,
+                    'launch',
+                    'twist_safety.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'enable_collision_monitor': LaunchConfiguration('enable_collision_monitor'),
+        }.items(),
+    )
+
+    # include launch files
+    teleop_rviz2 = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    get_package_share_directory('waywiser'),
+                    'launch',
+                    'teleop_rviz2.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'rviz_config': LaunchConfiguration('rviz_config'),
+            'teleop_config': LaunchConfiguration('teleop_config'),
+        }.items(),
+    )
+    # create launch description
+    ld = LaunchDescription()
+
+    # declare launch args
+    ld.add_action(use_sim_time_la)
+    ld.add_action(vehicle_config_la)
+    ld.add_action(enable_collision_monitor_la)
+    ld.add_action(rviz_config_la)
+    ld.add_action(teleop_config_la)
+
+    # start nodes
+    ld.add_action(truck)
+    ld.add_action(twist_safety)
+    ld.add_action(teleop_rviz2)
+
+    return ld

--- a/waywiser/launch/truck_waywise_autopilot.launch.py
+++ b/waywiser/launch/truck_waywise_autopilot.launch.py
@@ -1,0 +1,92 @@
+import os
+
+from ament_index_python import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration
+
+
+def generate_launch_description():
+    waywiser_dir = get_package_share_directory('waywiser')
+    waywiser_hwbringup_dir = get_package_share_directory('waywiser_hwbringup')
+    waywiser_rviz2_dir = get_package_share_directory('waywiser_rviz2')
+    teleop_dir = get_package_share_directory('waywiser_teleop')
+
+    # args that can be set from the command line or a default will be used
+    use_sim_time_la = DeclareLaunchArgument(
+        'use_sim_time', default_value='False', description='Use simulation clock'
+    )
+    vehicle_config_la = DeclareLaunchArgument(
+        'vehicle_config',
+        default_value=os.path.join(waywiser_hwbringup_dir, 'config/truck_small_scale.yaml'),
+        description='Full path to params file of vehicle',
+    )
+    enable_collision_monitor_la = DeclareLaunchArgument(
+        'enable_collision_monitor',
+        default_value='False',
+        description='Use Nav2 collision monitoring',
+    )
+    rviz_config_la = DeclareLaunchArgument(
+        'rviz_config',
+        default_value=os.path.join(waywiser_rviz2_dir, 'rviz/odom_reference_frame_truck.rviz'),
+        description='Full path of rviz display config file or path to their directory',
+    )
+    teleop_config_la = DeclareLaunchArgument(
+        'teleop_config',
+        default_value=os.path.join(teleop_dir, 'config/teleop.yaml'),
+        description='Full path to params file',
+    )
+
+    # include launch files
+    truck_manual_control = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    waywiser_dir,
+                    'launch',
+                    'truck_manual_control.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'vehicle_config': LaunchConfiguration('vehicle_config'),
+            'enable_collision_monitor': LaunchConfiguration('enable_collision_monitor'),
+            'rviz_config': LaunchConfiguration('rviz_config'),
+            'teleop_config': LaunchConfiguration('teleop_config'),
+        }.items(),
+    )
+
+    waywise_autopilot = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    waywiser_hwbringup_dir,
+                    'launch',
+                    'waywise_truck_autopilot.launch.py',
+                )
+            ]
+        ),
+        launch_arguments={
+            'use_sim_time': LaunchConfiguration('use_sim_time'),
+            'vehicle_config': LaunchConfiguration('vehicle_config'),
+        }.items(),
+    )
+
+    # create launch description
+    ld = LaunchDescription()
+
+    # declare launch args
+    ld.add_action(use_sim_time_la)
+    ld.add_action(enable_collision_monitor_la)
+    ld.add_action(rviz_config_la)
+    ld.add_action(teleop_config_la)
+    ld.add_action(vehicle_config_la)
+
+    # start nodes
+    ld.add_action(truck_manual_control)
+    ld.add_action(waywise_autopilot)
+
+    return ld

--- a/waywiser_hwbringup/config/truck_small_scale.yaml
+++ b/waywiser_hwbringup/config/truck_small_scale.yaml
@@ -32,6 +32,16 @@ waywise_truck_node:
     publish_odom_to_baselink_tf: true
     odom_publish_rate: 30 # currently same rate for both odom topic and odom->base_link tf
     imu_for_position_fusion: "vesc"
+    tof_sensors: [tof_trailer_rear, tof_trailer_right, tof_trailer_left]
+    tof_trailer_rear:
+      i2c_addr: 0x29
+      topic: "/truck/sensors/tof/trailer_rear"
+    # tof_trailer_right:
+    #   i2c_addr: 0x30
+    #   topic: "/truck/sensors/tof/trailer_right"
+    # tof_trailer_left:
+    #   i2c_addr: 0x31
+    #   topic: "/truck/sensors/tof/trailer_left"
 
 waywise_truck_autopilot_node:
   ros__parameters:

--- a/waywiser_hwbringup/config/truck_small_scale.yaml
+++ b/waywiser_hwbringup/config/truck_small_scale.yaml
@@ -1,0 +1,43 @@
+/**:
+  # general parameters shared by all waywise-related nodes
+  ros__parameters:
+    odom_frame: odom
+    base_frame: truck
+    trailer_frame: semitrailer
+    erpm_min: -10000.0
+    erpm_max: 10000.0
+    speed_to_erpm_factor: 5190.0
+    length: 0.5
+    width: 0.21
+    wheelbase: 0.3
+    min_turning_radius: 0.67 # wheelbase/tan(max_steering_angle)
+    max_angular_velocity: 2.5 # rad/s
+    standstill_velocity_threshold: 0.05
+    odom_topic: "/truck/odometry"
+    has_trailer: true
+    trailer_length: 0.96
+    trailer_width: 0.21
+    trailer_wheelbase: 0.64
+    angle_sensor_topic: "/truck/sensors/trailer_angle"
+
+waywise_truck_node:
+  ros__parameters:
+    servo_min: 0.0
+    servo_max: 0.5
+    servo_offset: 0.42
+    #steering_angle_to_servo_gain: -0.950
+    invert_servo_output: true
+    # TODO: limit erpm also based on current
+    # current_max: 30.0
+    publish_odom_to_baselink_tf: true
+    odom_publish_rate: 30 # currently same rate for both odom topic and odom->base_link tf
+    imu_for_position_fusion: "vesc"
+
+waywise_truck_autopilot_node:
+  ros__parameters:
+    autopilot_cmd_publish_rate: 30
+    waywise_control_tower_address: "127.0.0.1"
+    purepursuit_radius: 1.5
+    purepursuit_forward_gain: 1.0
+    purepursuit_reverse_gain: -1.0
+    adaptive_pure_pursuit: true

--- a/waywiser_hwbringup/launch/waywise_truck.launch.py
+++ b/waywiser_hwbringup/launch/waywise_truck.launch.py
@@ -1,0 +1,48 @@
+# launch file to bring up truck nodes
+
+import os
+
+from ament_index_python import get_package_share_directory
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+
+
+def generate_launch_description():
+    hw_bringup_dir = get_package_share_directory('waywiser_hwbringup')
+
+    # args that can be set from the command line or a default will be used
+    vehicle_config_la = DeclareLaunchArgument(
+        'vehicle_config',
+        default_value=os.path.join(hw_bringup_dir, 'config/truck_small_scale.yaml'),
+        description='Full path to params file of truck',
+    )
+
+    frame_prefix_la = DeclareLaunchArgument(
+        'frame_prefix',
+        default_value='/',
+        description='Prefix to publish robot transforms in',
+    )
+
+    # start nodes and use args to set parameters
+    waywise_node = Node(
+        package='waywiser_node',
+        executable='waywise_truck',
+        name='waywise_truck_node',
+        parameters=[LaunchConfiguration('vehicle_config')],
+        remappings=[('/cmd_vel', '/cmd_vel_out')],
+        arguments=['--ros-args', '--log-level', 'info'],
+    )
+
+    # create launch description
+    ld = LaunchDescription()
+
+    # declare launch arg
+    ld.add_action(vehicle_config_la)
+    ld.add_action(frame_prefix_la)
+
+    # start nodes
+    ld.add_action(waywise_node)
+
+    return ld

--- a/waywiser_node/CMakeLists.txt
+++ b/waywiser_node/CMakeLists.txt
@@ -80,8 +80,12 @@ add_executable(
   WayWise/external/pi-as5600/iic.c
   WayWise/external/pi-as5600/driver_as5600_basic.c
   WayWise/external/pi-as5600/raspberrypi4b_driver_as5600_interface.c
+  WayWise/external/VL53L0X/tof.h
+  WayWise/external/VL53L0X/tof.c
   WayWise/sensors/angle/as5600updater.cpp
   WayWise/sensors/angle/anglesensorupdater.cpp
+  WayWise/sensors/tof/vl53l0xtofsensor.cpp
+  WayWise/sensors/tof/tofsensor.h
   WayWise/vehicles/truckstate.cpp
   WayWise/vehicles/trailerstate.cpp)
 

--- a/waywiser_node/CMakeLists.txt
+++ b/waywiser_node/CMakeLists.txt
@@ -38,7 +38,8 @@ set(COMMON_WAYWISE_SOURCES
     WayWise/sensors/gnss/rtcmclient.cpp
     WayWise/logger/logger.cpp
     WayWise/communication/parameterserver.cpp
-    WayWise/sensors/camera/gimbal.h)
+    WayWise/sensors/camera/gimbal.h
+    WayWise/core/simplewatchdog.cpp)
 
 set(COMMON_WAYWISE_AP_SOURCES
     WayWise/vehicles/controller/motorcontroller.h
@@ -52,16 +53,37 @@ set(COMMON_WAYWISE_AP_SOURCES
     WayWise/communication/vehicleconnections/vehicleconnection.cpp
     WayWise/communication/mavlinkparameterserver.cpp)
 
+set(WAYWISE_CAR_SOURCES
+    WayWise/vehicles/carstate.cpp
+    WayWise/vehicles/controller/carmovementcontroller.cpp
+    WayWise/vehicles/controller/motorcontroller.h
+    WayWise/vehicles/controller/vescmotorcontroller.cpp
+    WayWise/external/vesc/vescpacket.cpp
+    WayWise/external/pi-bno055/i2c_bno055.c
+    WayWise/sensors/fusion/sdvpvehiclepositionfuser.cpp
+    WayWise/sensors/gnss/rtcm3_simple.cpp
+    WayWise/sensors/gnss/rtcmclient.cpp
+    WayWise/sensors/gnss/ublox.cpp
+    WayWise/sensors/gnss/ubloxrover.cpp
+    WayWise/sensors/imu/bno055orientationupdater.cpp
+    WayWise/sensors/imu/imuorientationupdater.cpp)
+
+add_executable(waywise_car src/waywise_car.cpp ${COMMON_WAYWISE_SOURCES}
+                           ${WAYWISE_CAR_SOURCES})
+
 add_executable(
-  waywise_car
-  src/waywise_car.cpp
+  waywise_truck
+  src/waywise_truck.cpp
   ${COMMON_WAYWISE_SOURCES}
-  WayWise/vehicles/carstate.cpp
-  WayWise/vehicles/controller/carmovementcontroller.cpp
-  WayWise/vehicles/controller/motorcontroller.h
-  WayWise/vehicles/controller/vescmotorcontroller.cpp
-  WayWise/external/vesc/vescpacket.cpp
-  WayWise/sensors/imu/imuorientationupdater.cpp)
+  ${WAYWISE_CAR_SOURCES}
+  WayWise/external/pi-as5600/driver_as5600.c
+  WayWise/external/pi-as5600/iic.c
+  WayWise/external/pi-as5600/driver_as5600_basic.c
+  WayWise/external/pi-as5600/raspberrypi4b_driver_as5600_interface.c
+  WayWise/sensors/angle/as5600updater.cpp
+  WayWise/sensors/angle/anglesensorupdater.cpp
+  WayWise/vehicles/truckstate.cpp
+  WayWise/vehicles/trailerstate.cpp)
 
 add_executable(
   waywise_car_autopilot
@@ -82,10 +104,12 @@ add_executable(
   WayWise/vehicles/trailerstate.cpp)
 
 target_include_directories(waywise_car PRIVATE WayWise/)
+target_include_directories(waywise_truck PRIVATE WayWise/)
 target_include_directories(waywise_car_autopilot PRIVATE WayWise/)
 target_include_directories(waywise_truck_autopilot PRIVATE WayWise/)
 
 target_link_libraries(waywise_car Qt5::Core Qt5::SerialPort Qt5::Network)
+target_link_libraries(waywise_truck Qt5::Core Qt5::SerialPort Qt5::Network)
 target_link_libraries(
   waywise_car_autopilot
   Qt5::Core
@@ -101,6 +125,13 @@ target_link_libraries(
 
 ament_target_dependencies(
   waywise_car
+  rclcpp
+  std_msgs
+  nav_msgs
+  geometry_msgs
+  tf2_ros)
+ament_target_dependencies(
+  waywise_truck
   rclcpp
   std_msgs
   nav_msgs
@@ -124,6 +155,7 @@ ament_target_dependencies(
   tf2_geometry_msgs)
 
 install(TARGETS waywise_car DESTINATION lib/${PROJECT_NAME})
+install(TARGETS waywise_truck DESTINATION lib/${PROJECT_NAME})
 install(TARGETS waywise_car_autopilot DESTINATION lib/${PROJECT_NAME})
 install(TARGETS waywise_truck_autopilot DESTINATION lib/${PROJECT_NAME})
 

--- a/waywiser_node/src/waywise_truck.cpp
+++ b/waywiser_node/src/waywise_truck.cpp
@@ -2,6 +2,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <map>
 
 #include "WayWise/core/simplewatchdog.h"
 #include "WayWise/logger/logger.h"
@@ -11,6 +12,7 @@
 #include "WayWise/sensors/gnss/ubloxrover.h"
 #include "WayWise/sensors/imu/bno055orientationupdater.h"
 #include "WayWise/sensors/imu/imuorientationupdater.h"
+#include "WayWise/sensors/tof/vl53l0xtofsensor.h"
 #include "WayWise/vehicles/truckstate.h"
 #include "WayWise/vehicles/trailerstate.h"
 #include "WayWise/vehicles/controller/carmovementcontroller.h"
@@ -221,6 +223,48 @@ public:
 
 
     if (has_trailer_) {
+      // ToF Sensors
+      std::vector<std::string> tof_sensor_names = this->declare_parameter<std::vector<std::string>>(
+        "tof_sensors", {}, rcl_interfaces::msg::ParameterDescriptor{});
+
+      RCLCPP_WARN(
+        this->get_logger(),
+        "ToF sensors: %ld",
+        tof_sensor_names.size());
+
+
+      if (tof_sensor_names.size() > 1) {
+        RCLCPP_WARN(
+          this->get_logger(),
+          "More than one ToF sensor is not currently supported. "
+          "Only the first sensor will be used: '%s'. Ignoring others.",
+          tof_sensor_names[0].c_str());
+
+        tof_sensor_names.resize(1); // TODO: enable setting multiple tof sensors
+      }
+      for (const auto & tof_sensor_name : tof_sensor_names) {
+        int i2c_addr =
+          this->declare_parameter<int>(tof_sensor_name + ".i2c_addr", 0);
+        std::string topic_name = this->declare_parameter<std::string>(
+          tof_sensor_name + ".topic", "");
+
+        ToFSensorInfo tof_sensor_info;
+        tof_sensor_info.i2c_addr = i2c_addr;
+        tof_sensor_info.topic_name = topic_name;
+
+        // tof_sensor_info.sensor.reset(new VL53L0XToFSensor(i2c_addr)); // TODO: enable setting i2c address
+        tof_sensor_info.sensor.reset(new VL53L0XToFSensor());
+        QObject::connect(
+          tof_sensor_info.sensor.get(), &ToFSensor::updatedDistance, this,
+          [this, tof_sensor_name](double distance) {
+            updated_tof_distance_callback(tof_sensor_name, distance);
+          });
+
+        tof_sensor_info.publisher = this->create_publisher<std_msgs::msg::Float32>(topic_name, 10);
+
+        tof_sensors_[tof_sensor_name] = tof_sensor_info;
+      }
+
       // Angle Sensor
       mAngleSensorUpdater.reset(new AS5600Updater(mTruckState, angle_sensor_offset_));
     }
@@ -363,6 +407,18 @@ private:
     angle_pub_->publish(angle_msg);
   }
 
+  void updated_tof_distance_callback(const std::string & tof_sensor_name, double distance_m)
+  {
+    auto sensor_info = tof_sensors_[tof_sensor_name];
+
+    std_msgs::msg::Float32 msg;
+    msg.data = static_cast<float>(distance_m);
+    sensor_info.publisher->publish(msg);
+    RCLCPP_INFO(
+      this->get_logger(), "Published ToF distance %.2f from %s", distance_m,
+      tof_sensor_name.c_str());
+  }
+
   void twist_callback(const geometry_msgs::msg::Twist::SharedPtr twist_msg)
   {
     // RCLCPP_INFO(this->get_logger(), "got Twist: linear %f, angular %f",
@@ -460,6 +516,15 @@ private:
   RtcmClient * rtcmClient;
   SimpleWatchdog * watchdog;
   QSharedPointer<AngleSensorUpdater> mAngleSensorUpdater;
+  QSharedPointer<ToFSensor> mToFSensor;
+  struct ToFSensorInfo
+  {
+    int i2c_addr;
+    std::string topic_name;
+    QSharedPointer<ToFSensor> sensor;
+    rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr publisher;
+  };
+  std::map<std::string, ToFSensorInfo> tof_sensors_;
 };
 
 int main(int argc, char * argv[])

--- a/waywiser_node/src/waywise_truck.cpp
+++ b/waywiser_node/src/waywise_truck.cpp
@@ -267,6 +267,7 @@ public:
 
       // Angle Sensor
       mAngleSensorUpdater.reset(new AS5600Updater(mTruckState, angle_sensor_offset_));
+      mTruckState->setSimulateTrailer(!mAngleSensorUpdater->isConnected());
     }
 
     // Odometry
@@ -317,7 +318,6 @@ private:
       previousTimeCalled).count();
 
     publish_odom_and_tf(timePassed_ms);
-    publish_trailer_angle(); // TODO: connect this with updatedAngleSensor signal
 
     previousTimeCalled = thisTimeCalled;
   }
@@ -391,6 +391,8 @@ private:
         trailer_tf.transform.rotation.w = cos(trailer_yaw_rad / 2.0);
 
         tf_pub_->sendTransform(trailer_tf);
+
+        publish_trailer_angle();
       }
     }
 

--- a/waywiser_node/src/waywise_truck.cpp
+++ b/waywiser_node/src/waywise_truck.cpp
@@ -1,0 +1,487 @@
+#include <chrono>
+#include <functional>
+#include <memory>
+#include <string>
+
+#include "WayWise/core/simplewatchdog.h"
+#include "WayWise/logger/logger.h"
+#include "WayWise/sensors/angle/as5600updater.h"
+#include "WayWise/sensors/fusion/sdvpvehiclepositionfuser.h"
+#include "WayWise/sensors/gnss/rtcmclient.h"
+#include "WayWise/sensors/gnss/ubloxrover.h"
+#include "WayWise/sensors/imu/bno055orientationupdater.h"
+#include "WayWise/sensors/imu/imuorientationupdater.h"
+#include "WayWise/vehicles/truckstate.h"
+#include "WayWise/vehicles/trailerstate.h"
+#include "WayWise/vehicles/controller/carmovementcontroller.h"
+#include "WayWise/vehicles/controller/vescmotorcontroller.h"
+
+#include <QCoreApplication>
+#include <QObject>
+
+#include "geometry_msgs/msg/transform_stamped.hpp"
+#include "nav_msgs/msg/odometry.hpp"
+#include "rclcpp/rclcpp.hpp"
+#include "std_msgs/msg/bool.hpp"
+#include "std_msgs/msg/float32.hpp"
+#include "std_msgs/msg/string.hpp"
+#include "tf2_ros/transform_broadcaster.h"
+#include "mavsdk/mavsdk.h"
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+
+class WayWiseTruck : public QObject, public rclcpp::Node
+{
+  Q_OBJECT
+
+public:
+  WayWiseTruck()
+  : QObject(), Node("waywise_truck")
+  {
+    // -- ROS --
+    // get ROS parameters
+    odom_frame_ = declare_parameter("odom_frame", "odom");
+    base_frame_ = declare_parameter("base_frame", "base_link");
+    trailer_frame_ = declare_parameter("trailer_frame", "trailer");
+
+    erpm_min_ = this->declare_parameter("erpm_min", 0.0);
+    erpm_max_ = this->declare_parameter("erpm_max", 0.0);
+    speed_to_erpm_factor_ = this->declare_parameter("speed_to_erpm_factor", 0.0);
+
+    invert_servo_output_ = this->declare_parameter("invert_servo_output", false);
+    servo_offset_ = this->declare_parameter("servo_offset", 0.5);
+    servo_min_ = this->declare_parameter("servo_min", 0.0);
+    servo_max_ = this->declare_parameter("servo_max", 1.0);
+
+    length_ = this->declare_parameter("length", 0.33);
+    width_ = this->declare_parameter("width", 0.33);
+    wheelbase_ = this->declare_parameter("wheelbase", 0.33);
+    min_turning_radius_ = this->declare_parameter("min_turning_radius", 0.67);
+    odom_publish_rate_ = this->declare_parameter("odom_publish_rate", 30);
+    publish_odom_to_baselink_tf_ = this->declare_parameter("publish_odom_to_baselink_tf", true);
+    imu_for_position_fusion_ = declare_parameter("imu_for_position_fusion", "");
+    odom_topic_ = this->declare_parameter("odom_topic", "/odom");
+
+    max_angular_velocity_ = this->declare_parameter("max_angular_velocity", 0.5);
+    standstill_velocity_threshold_ = this->declare_parameter("standstill_velocity_threshold", 0.05);
+
+    has_trailer_ = this->declare_parameter("has_trailer", false);
+
+    if (has_trailer_) {
+      trailer_length_ = this->declare_parameter("trailer_length", 10.0);
+      trailer_width_ = this->declare_parameter("trailer_width", 6.0);
+      trailer_wheelbase_ = this->declare_parameter("trailer_wheelbase", 8.0);
+
+      angle_sensor_offset_ = this->declare_parameter("angle_sensor_offset", 0.0);
+      angle_sensor_topic_ = this->declare_parameter("angle_sensor_topic", "/sensors/angle");
+    }
+
+    // publishers
+    odom_pub_ = create_publisher<nav_msgs::msg::Odometry>(odom_topic_, 10);
+    if (publish_odom_to_baselink_tf_) {
+      tf_pub_.reset(new tf2_ros::TransformBroadcaster(this));
+    }
+
+    if (has_trailer_) {
+      angle_pub_ = this->create_publisher<std_msgs::msg::Float32>(angle_sensor_topic_, 10);
+    }
+
+    mUpdateVehicleStatePeriod =
+      std::chrono::milliseconds((int)std::round(1000.0 / odom_publish_rate_));
+
+    // subscribers
+    twist_sub_ = this->create_subscription<geometry_msgs::msg::Twist>(
+      "/cmd_vel", 10, std::bind(&WayWiseTruck::twist_callback, this, _1));
+
+    // -- WayWise --
+    mTruckState.reset(new TruckState);
+    mTruckState->setLength(length_);
+    mTruckState->setWidth(width_);
+    mTruckState->setAxisDistance(wheelbase_);
+    mTruckState->setMaxSteeringAngle(atan(wheelbase_ / min_turning_radius_));
+    if (has_trailer_) {
+      mTrailerState.reset(new TrailerState((int) MAV_COMP_ID_USER1, Qt::white));
+      mTrailerState->setLength(trailer_length_);
+      mTrailerState->setWidth(trailer_width_);
+      mTrailerState->setWheelBase(trailer_wheelbase_);
+
+      mTruckState->setTrailingVehicle(mTrailerState);
+    }
+
+    // --- Lower-level control setup ---
+    mCarMovementController.reset(new CarMovementController(mTruckState));
+    mCarMovementController->setSpeedToRPMFactor(speed_to_erpm_factor_);
+
+    // setup and connect VESC, simulate movements if unable to connect
+    mVESCMotorController.reset(new VESCMotorController());
+    foreach(const QSerialPortInfo & portInfo, QSerialPortInfo::availablePorts())
+    {
+      if (portInfo.description().toLower().replace("-", "").contains("chibios")) { // assumption: Serial device with ChibiOS in
+                                                                                   // description is VESC
+        mVESCMotorController->connectSerial(portInfo);
+        RCLCPP_INFO(
+          get_logger(), "VESCMotorController connected to: %s",
+          portInfo.systemLocation().toLocal8Bit().data());
+      }
+    }
+
+    if (mVESCMotorController->isSerialConnected()) {
+      mCarMovementController->setMotorController(mVESCMotorController);
+      mVESCMotorController->setPollValuesPeriod(mUpdateVehicleStatePeriod.count());
+
+      // VESC is a special case that can also control the servo
+      const auto servoController = mVESCMotorController->getServoController();
+      servoController->setInvertOutput(invert_servo_output_);
+      servoController->setServoRange(servo_max_ - servo_min_);
+      servoController->setServoCenter(servo_offset_);
+      mCarMovementController->setServoController(servoController);
+
+      is_in_simulation_mode_ = false;
+      waywise_posType_used_ = PosType::fused;
+    } else {
+      // publish periodically with timer when no motorcontroller connected
+      // (simulation)
+      is_in_simulation_mode_ = true;
+      waywise_posType_used_ = PosType::simulated;
+      simulation_timer_ =
+        this->create_wall_timer(
+        mUpdateVehicleStatePeriod,
+        std::bind(&WayWiseTruck::simulation_timer_callback, this));
+
+      RCLCPP_INFO(
+        get_logger(),
+        "VESCMotorController is not connected. "
+        "waywise_truck is in simulation mode!");
+    }
+
+    // --- Positioning setup ---
+    // Position Fuser
+    positionFuser = new SDVPVehiclePositionFuser(this);
+    // GNSS (with fused IMU when using u-blox F9R)
+    mUbloxRover.reset(new UbloxRover(mTruckState));
+    foreach(const QSerialPortInfo & portInfo, QSerialPortInfo::availablePorts()) {
+      // qDebug()<<portInfo.manufacturer();
+      if (portInfo.manufacturer().toLower().replace("-", "").contains("ublox")) {
+        if (mUbloxRover->connectSerial(portInfo)) {
+          qDebug() << "UbloxRover connected to:" << portInfo.systemLocation();
+
+          //mUbloxRover->setIMUOrientationOffset(0.0, 0.0, 0.0);
+        }
+      }
+    }
+
+    rtcmClient = new RtcmClient(this);
+    QObject::connect(
+      mUbloxRover.get(), &UbloxRover::updatedGNSSPositionAndYaw, positionFuser,
+      &SDVPVehiclePositionFuser::correctPositionAndYawGNSS);
+
+    // -- NTRIP/TCP client setup for feeding RTCM data into GNSS receiver
+    QObject::connect(
+      mUbloxRover.get(), &UbloxRover::gotNmeaGga, rtcmClient, &RtcmClient::forwardNmeaGgaToServer);
+    QObject::connect(
+      rtcmClient, &RtcmClient::rtcmData,
+      mUbloxRover.get(), &UbloxRover::writeRtcmToUblox);
+    QObject::connect(
+      rtcmClient, &RtcmClient::baseStationPosition,
+      mUbloxRover.get(), &UbloxRover::setEnuRef);
+    if (rtcmClient->connectWithInfoFromFile("./rtcmServerInfo.txt")) {
+      qDebug() << "RtcmClient: connected to" << QString(
+        rtcmClient->getCurrentHost() + ":" + QString::number(rtcmClient->getCurrentPort()));
+    } else {
+      qDebug() << "RtcmClient: not connected";
+    }
+
+    // IMU
+    if (!imu_for_position_fusion_.empty()) {
+      if (imu_for_position_fusion_ == "vesc") {
+        if (mVESCMotorController->isSerialConnected()) {
+          mIMUOrientationUpdater = mVESCMotorController->getIMUOrientationUpdater(mTruckState);
+          QObject::connect(
+            mIMUOrientationUpdater.get(), &IMUOrientationUpdater::updatedIMUOrientation, positionFuser,
+            &SDVPVehiclePositionFuser::correctPositionAndYawIMU);
+          RCLCPP_INFO(this->get_logger(), "Using vesc IMU for position fusion.");
+        } else {
+          RCLCPP_INFO(
+            get_logger(),
+            "vesc IMU is configured for position fusion but VESCMotorController is not connected.");
+        }
+      } else if (imu_for_position_fusion_ == "bno055") {
+        mIMUOrientationUpdater.reset(new BNO055OrientationUpdater(mTruckState, "/dev/i2c-1"));
+        QObject::connect(
+          mIMUOrientationUpdater.get(), &IMUOrientationUpdater::updatedIMUOrientation, positionFuser,
+          &SDVPVehiclePositionFuser::correctPositionAndYawIMU);
+        RCLCPP_INFO(this->get_logger(), "Using bno055 IMU for position fusion.");
+      } else {
+        RCLCPP_INFO(
+          get_logger(),
+          "Unknown IMU variant is requested for position fusion!");
+      }
+    }
+
+
+    if (has_trailer_) {
+      // Angle Sensor
+      mAngleSensorUpdater.reset(new AS5600Updater(mTruckState, angle_sensor_offset_));
+    }
+
+    // Odometry
+    QObject::connect(
+      mCarMovementController.get(), &CarMovementController::updatedOdomPositionAndYaw, positionFuser,
+      &SDVPVehiclePositionFuser::correctPositionAndYawOdom);
+    QObject::connect(
+      mCarMovementController.get(), &CarMovementController::updatedOdomPositionAndYaw, this,
+      &WayWiseTruck::updated_waywise_odomPos_callback);
+
+    // Watchdog that warns when EventLoop is slowed down
+    watchdog = new SimpleWatchdog(this);
+    RCLCPP_INFO(
+      get_logger(),
+      "Waywise truck node initialized!");
+  }
+
+private:
+  void simulation_timer_callback()
+  {
+    auto thisTimeCalled = std::chrono::high_resolution_clock::now();
+    static auto previousTimeCalled = thisTimeCalled - mUpdateVehicleStatePeriod;
+    double timePassed_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+      thisTimeCalled -
+      previousTimeCalled).count();
+
+    mTruckState->simulationStep(timePassed_ms, waywise_posType_used_);
+
+    publish_odom_and_tf(timePassed_ms);
+
+    previousTimeCalled = thisTimeCalled;
+  }
+
+  void updated_waywise_odomPos_callback(
+    QSharedPointer<VehicleState> vehicleState,
+    double distanceDriven)
+  {
+    // suppress 'unused' warnings
+    (void)vehicleState;
+    (void)distanceDriven;
+
+    auto thisTimeCalled = std::chrono::high_resolution_clock::now();
+    static auto previousTimeCalled = thisTimeCalled - mUpdateVehicleStatePeriod;
+    double timePassed_ms =
+      std::chrono::duration_cast<std::chrono::milliseconds>(
+      thisTimeCalled -
+      previousTimeCalled).count();
+
+    publish_odom_and_tf(timePassed_ms);
+    publish_trailer_angle(); // TODO: connect this with updatedAngleSensor signal
+
+    previousTimeCalled = thisTimeCalled;
+  }
+
+  void publish_odom_and_tf(double timePassed_ms)
+  {
+    PosPoint currentPosition = mTruckState->getPosition(waywise_posType_used_);
+    if (waywise_posType_used_ != PosType::fused) {
+      currentPosition.setType(PosType::fused); // the 'fused' position type is communicated to topics
+                                               // & potentially MAVLINK
+      mTruckState->setPosition(currentPosition);
+    }
+
+    double truck_x = currentPosition.getX();
+    double truck_y = currentPosition.getY();
+    double truck_yaw_rad = currentPosition.getYaw() * M_PI / 180.0;
+    static double previousYawRad_ = truck_yaw_rad;
+
+    // -- Prepare Odom
+    auto odom = nav_msgs::msg::Odometry();
+    odom.header.stamp = now();
+    odom.header.frame_id = odom_frame_;
+    odom.child_frame_id = base_frame_;
+
+    // Position in the coordinate frame given by header.frame_id
+    odom.pose.pose.position.x = truck_x;
+    odom.pose.pose.position.y = truck_y;
+    odom.pose.pose.orientation.x = 0.0;
+    odom.pose.pose.orientation.y = 0.0;
+    odom.pose.pose.orientation.z = sin(truck_yaw_rad / 2.0);
+    odom.pose.pose.orientation.w = cos(truck_yaw_rad / 2.0);
+
+    // TODO: position uncertainty?
+
+    // Velocity in the coordinate frame given by child_frame_id
+    odom.twist.twist.linear.x = mTruckState->getSpeed();
+    odom.twist.twist.linear.y = 0.0;
+    odom.twist.twist.angular.z = (truck_yaw_rad - previousYawRad_) / (timePassed_ms / 1000.0);
+
+    // TODO: velocity uncertainty?
+
+    if (publish_odom_to_baselink_tf_) {
+      // -- Prepare Transform
+      auto tf = geometry_msgs::msg::TransformStamped();
+      tf.header.frame_id = odom_frame_;
+      tf.child_frame_id = base_frame_;
+      tf.header.stamp = now();
+      tf.transform.translation.x = truck_x;
+      tf.transform.translation.y = truck_y;
+      tf.transform.translation.z = 0.0;
+      tf.transform.rotation = odom.pose.pose.orientation;
+
+      // -- Publish Transform
+      tf_pub_->sendTransform(tf);
+
+      // -- Calculate and Publish Trailer Transform
+      if (has_trailer_) {
+        double trailer_angle_rad = mTruckState->getTrailerAngleRadians();
+        double trailer_x = truck_x - cos(truck_yaw_rad + trailer_angle_rad) * trailer_wheelbase_;
+        double trailer_y = truck_y - sin(truck_yaw_rad + trailer_angle_rad) * trailer_wheelbase_;
+        double trailer_yaw_rad = truck_yaw_rad + trailer_angle_rad;
+
+        auto trailer_tf = geometry_msgs::msg::TransformStamped();
+        trailer_tf.header.frame_id = odom_frame_;
+        trailer_tf.child_frame_id = trailer_frame_;
+        trailer_tf.header.stamp = now();
+        trailer_tf.transform.translation.x = trailer_x;
+        trailer_tf.transform.translation.y = trailer_y;
+        trailer_tf.transform.translation.z = 0.0;
+        trailer_tf.transform.rotation.z = sin(trailer_yaw_rad / 2.0);
+        trailer_tf.transform.rotation.w = cos(trailer_yaw_rad / 2.0);
+
+        tf_pub_->sendTransform(trailer_tf);
+      }
+    }
+
+    // -- Publish Odom
+    odom_pub_->publish(odom);
+
+    previousYawRad_ = truck_yaw_rad;
+  }
+
+  void publish_trailer_angle()
+  {
+    std_msgs::msg::Float32 angle_msg;
+    angle_msg.data = mTruckState->getTrailerAngleDegrees();
+    angle_pub_->publish(angle_msg);
+  }
+
+  void twist_callback(const geometry_msgs::msg::Twist::SharedPtr twist_msg)
+  {
+    // RCLCPP_INFO(this->get_logger(), "got Twist: linear %f, angular %f",
+    // twist_msg->linear.x, twist_msg->angular.z);
+    float clipped_linear_velocity =
+      (speed_to_erpm_factor_ > 0.0) ?
+      clip_min_max(
+      speed_to_erpm_factor_ * twist_msg->linear.x, erpm_min_,
+      erpm_max_) / speed_to_erpm_factor_ :
+      0.0;
+    clipped_linear_velocity =
+      (fabs(clipped_linear_velocity) >=
+      standstill_velocity_threshold_) ? clipped_linear_velocity : 0.0;
+    mCarMovementController->setDesiredSpeed(clipped_linear_velocity);
+
+    float clipped_angular_velocity = clip_min_max(
+      twist_msg->angular.z, -max_angular_velocity_,
+      max_angular_velocity_);
+    if (fabs(clipped_linear_velocity) >= standstill_velocity_threshold_) {
+      // NOTE / TODO: WayWise has a sign error here (curvature in wrong direction)
+      float desired_steering_curvature = -(clipped_angular_velocity / twist_msg->linear.x);  // ω = v/r => 1/r = ω/v
+      mCarMovementController->setDesiredSteeringCurvature(desired_steering_curvature);
+      // RCLCPP_INFO(this->get_logger(), "clipped_linear_velocity %f,
+      // desired_steering_curvature %f", clipped_linear_velocity,
+      // desired_steering_curvature);
+    } else {
+      // NOTE / TODO: WayWise has a sign error here (steering in wrong direction)
+      float desired_steering =
+        (fabs(clipped_angular_velocity) >=
+        0.01) ? -(clipped_angular_velocity / max_angular_velocity_) : 0.0;
+      mCarMovementController->setDesiredSteering(desired_steering);
+      // RCLCPP_INFO(
+      //   this->get_logger(), "clipped_angular_velocity %f, desired_steering %f", twist_msg->angular.z, clipped_angular_velocity,
+      //   desired_steering);
+    }
+  }
+
+  float clip_min_max(float value, float min_value, float max_value) const
+  {
+    return std::min(
+      std::max(value, (min_value + std::numeric_limits<float>::epsilon())),
+      (max_value - std::numeric_limits<float>::epsilon()));
+  }
+
+  // ROS parameters
+  std::string odom_frame_, odom_topic_;
+  std::string base_frame_;
+  std::string trailer_frame_;
+
+  float erpm_min_, erpm_max_, speed_to_erpm_factor_;
+
+  bool invert_servo_output_;
+  float servo_min_, servo_max_, servo_offset_;
+
+  float length_, width_, wheelbase_, min_turning_radius_;
+  float trailer_length_, trailer_width_, trailer_wheelbase_;
+
+  bool publish_odom_to_baselink_tf_;
+  int odom_publish_rate_;
+  std::string imu_for_position_fusion_;
+
+  float angle_sensor_offset_;
+
+
+  float standstill_velocity_threshold_;
+  float max_angular_velocity_;
+
+  std::string angle_sensor_topic_;
+  bool has_trailer_;
+
+  // internal variables
+  bool is_in_simulation_mode_ = true;
+  PosType waywise_posType_used_ = PosType::simulated;
+
+  // publishers
+  rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
+  std::shared_ptr<tf2_ros::TransformBroadcaster> tf_pub_;
+  rclcpp::Publisher<std_msgs::msg::Float32>::SharedPtr angle_pub_;
+
+  rclcpp::TimerBase::SharedPtr simulation_timer_;
+
+  // subscribers
+  rclcpp::Subscription<geometry_msgs::msg::Twist>::SharedPtr twist_sub_;
+  rclcpp::Subscription<std_msgs::msg::Float32>::SharedPtr angle_sensor_sub_;
+
+  // WayWise
+  std::chrono::milliseconds mUpdateVehicleStatePeriod;
+  QSharedPointer<TruckState> mTruckState;
+  QSharedPointer<TrailerState> mTrailerState;
+  QSharedPointer<CarMovementController> mCarMovementController;
+  QSharedPointer<VESCMotorController> mVESCMotorController;
+  QSharedPointer<IMUOrientationUpdater> mIMUOrientationUpdater;
+  QSharedPointer<UbloxRover> mUbloxRover;
+  SDVPVehiclePositionFuser * positionFuser;
+  RtcmClient * rtcmClient;
+  SimpleWatchdog * watchdog;
+  QSharedPointer<AngleSensorUpdater> mAngleSensorUpdater;
+};
+
+int main(int argc, char * argv[])
+{
+  rclcpp::init(argc, argv);
+  QCoreApplication a(argc, argv);
+
+  a.processEvents();
+
+  auto waywiseNode = std::make_shared<WayWiseTruck>();
+  rclcpp::executors::MultiThreadedExecutor exec;
+  exec.add_node(waywiseNode);
+
+  while (rclcpp::ok()) {
+    exec.spin_some();
+    a.processEvents();
+  }
+
+  exec.remove_node(waywiseNode);
+  rclcpp::shutdown();
+
+  return 0;
+}
+
+#include "waywise_truck.moc"

--- a/waywiser_rviz2/rviz/odom_reference_frame_truck.rviz
+++ b/waywiser_rviz2/rviz/odom_reference_frame_truck.rviz
@@ -1,0 +1,326 @@
+Panels:
+  - Class: rviz_common/Displays
+    Help Height: 0
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /TF1/Tree1/odom1
+      Splitter Ratio: 0.6000000238418579
+    Tree Height: 703
+  - Class: rviz_common/Selection
+    Name: Selection
+  - Class: rviz_common/Tool Properties
+    Expanded:
+      - /2D Goal Pose1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz_common/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz_common/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+  - Class: slam_toolbox::SlamToolboxPlugin
+    Name: SlamToolboxPlugin
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz_default_plugins/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: -0.20000000298023224
+      Plane: XY
+      Plane Cell Count: 100
+      Reference Frame: odom
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+        odom:
+          Value: true
+        semitrailer:
+          Value: true
+        truck:
+          Value: true
+      Marker Scale: 1
+      Name: TF
+      Show Arrows: false
+      Show Axes: true
+      Show Names: true
+      Tree:
+        odom:
+          semitrailer: {}
+          truck: {}
+      Update Interval: 0
+      Value: true
+    - Alpha: 1
+      Class: rviz_default_plugins/RobotModel
+      Collision Enabled: false
+      Description File: ""
+      Description Source: Topic
+      Description Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: robot_description
+      Enabled: true
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Mass Properties:
+        Inertia: false
+        Mass: false
+      Name: Robot model
+      TF Prefix: ""
+      Update Interval: 0
+      Value: true
+      Visual Enabled: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/LaserScan
+      Color: 229; 165; 10
+      Color Transformer: FlatColor
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: true
+      Max Color: 255; 255; 255
+      Max Intensity: 0
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Lidar scan
+      Position Transformer: XYZ
+      Selectable: false
+      Size (Pixels): 3
+      Size (m): 0.05000000074505806
+      Style: Spheres
+      Topic:
+        Depth: 1
+        Durability Policy: Volatile
+        Filter size: 1
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /scan_lidar
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+    - Alpha: 0.20000000298023224
+      Autocompute Intensity Bounds: false
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: x
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: Intensity
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 10
+      Min Color: 0; 0; 0
+      Min Intensity: 0.30000001192092896
+      Name: Depth pointcloud
+      Position Transformer: XYZ
+      Selectable: false
+      Size (Pixels): 1
+      Size (m): 0.009999999776482582
+      Style: Boxes
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /sensors/camera/depth/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Alpha: 1
+      Class: rviz_default_plugins/Polygon
+      Color: 165; 29; 45
+      Enabled: true
+      Name: Collison monitoring zone
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        Filter size: 10
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /polygon_slowdown
+      Value: true
+    - Class: rviz_default_plugins/Image
+      Enabled: false
+      Max Value: 1
+      Median window: 5
+      Min Value: 0
+      Name: Object detection
+      Normalize Range: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /sensors/camera/color/yolov8_annotated_image
+      Value: false
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz_default_plugins/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: RGB8
+      Decay Time: 0
+      Enabled: false
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: Color pointcloud
+      Position Transformer: XYZ
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: System Default
+        Filter size: 10
+        History Policy: System Default
+        Reliability Policy: System Default
+        Value: /sensors/camera/color/points
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: false
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: false
+      Name: 3D bounding box markers
+      Namespaces: {}
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /sensors/camera/color/bbox_3d_markers
+      Value: false
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: odom
+    Frame Rate: 10
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/Interact
+      Hide Inactive Objects: true
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/FocusCamera
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+    - Class: rviz_default_plugins/SetInitialPose
+      Covariance x: 0.25
+      Covariance y: 0.25
+      Covariance yaw: 0.06853891909122467
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /initialpose
+    - Class: rviz_default_plugins/SetGoal
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /goal_pose
+    - Class: rviz_default_plugins/PublishPoint
+      Single click: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /clicked_point
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/Orbit
+      Distance: 10
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 1.5697963237762451
+      Target Frame: truck
+      Value: Orbit (rviz)
+      Yaw: 3.1490659713745117
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: true
+  Height: 917
+  Hide Left Dock: true
+  Hide Right Dock: false
+  Object detection:
+    collapsed: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000019e000002fcfc020000000afb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073000000003d000002fc000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261fb000000220053006c0061006d0054006f006f006c0062006f00780050006c007500670069006e0000000353000001cc0000018500fffffffb00000020004f0062006a00650063007400200064006500740065006300740069006f006e000000024c0000016b0000002800ffffff00000001000001000000037afc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003d0000037a000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000050000000039fc0100000002fb0000000800540069006d0065010000000000000500000002fb00fffffffb0000000800540069006d0065010000000000000450000000000000000000000500000002fc00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  SlamToolboxPlugin:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1280
+  X: 1244
+  Y: 27


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

feature

* **What is the current behavior?** (You can also link to an open issue here)

there is no direct support for controlling a physical semitruck prototype

* **What is the new behavior (if this is a feature change)?**

A node is created in waywiser_node package that uses waywise truckstate implementation to control a truck powered by vesc, along with gnss, imu, hitch angle and tof sensors. 

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

* **Other information**:


