### PR TITLE
Fix emergency stop state handling

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 ### Pre-submission Checklist
 
-Before creating this PR, ensure you have completed the following:
+Before creating this PR, ensure you have completed the following by filling in the checkboxes with 'x':
 
 - [ ] Followed the [Developer Guide](./DEVELOPER_GUIDE.md) and coding standards
 - [ ] Run all tests: `colcon test --base-paths src/WayWiseR/`
@@ -12,20 +12,20 @@ Before creating this PR, ensure you have completed the following:
 
 * **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
 
-  
+  > 
 
 * **What is the current behavior?** (You can also link to an open issue here)
 
-  
+  > 
 
 * **What is the new behavior (if this is a feature change)?**
 
-  
+  > 
 
 * **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
 
-  
+  > 
 
 * **Other information**:
 
-  
+  > 

--- a/waywiser_twist_safety/cpp_src/emergency_stop_monitor.cpp
+++ b/waywiser_twist_safety/cpp_src/emergency_stop_monitor.cpp
@@ -107,15 +107,20 @@ private:
         twist_msg.angular.z = 0.0;
         twist_publisher_->publish(twist_msg);
       }
-    } else {
+    } else if (emergency_stop_target_state_msg->state == EmergencyStopState::CLEAR) {
       if (is_emergency_stop_active()) {
         current_emergency_stop_state_msg.state = EmergencyStopState::CLEAR;
         RCLCPP_INFO(
           get_logger(), "Emergency stop CLEARED by %s.",
           emergency_stop_target_state_msg->sender_id.c_str());
       }
+    } else {
+      RCLCPP_WARN(
+        get_logger(),
+        "Received emergency stop request with unknown state %d from %s. Ignoring.",
+        emergency_stop_target_state_msg->state,
+        emergency_stop_target_state_msg->sender_id.c_str());
     }
-
   }
 
   void emergency_stop_state_publisher_timer_callback()


### PR DESCRIPTION
## Summary
- avoid clearing emergency stops on unknown state
- log a warning for unknown emergency stop requests

## Testing
- `colcon test --packages-select waywiser_twist_safety` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b69c3275c08321a9fc186587384157