### PR TITLE
docs: Update README with Python 3.10 setup and correct citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ WayWiseR is divided into modular ROS2 packages:
 
    ```bash
    cd $WAYWISER_WS
-   uv venv --clear
+   uv venv --python 3.10 --clear
    source .venv/bin/activate
    export PYTHONPATH=$WAYWISER_WS/.venv/lib/python3.10/site-packages:$PYTHONPATH
    uv pip install -e src/WayWiseR
@@ -155,13 +155,13 @@ Previous maintainers:
 If you use WayWiseR in your research, please cite:
 
 ```bibtex
-@inproceedings{avula2025waywiser,
-  title     = {WayWiseR: A Rapid Prototyping Platform for Validating Connected and Automated Vehicles},
-  author    = {Avula, Ramana Reddy and Damschen, Marvin and Mirzai, Aria and Lundgren, Karl and Farooqui, Ashfaq and Thorsen, Anders},
-  booktitle = {Proceedings of the 13th International Conference on Control, Mechatronics and Automation (ICCMA)},
-  year      = {2025},
-  address   = {Paris, France},
-  publisher = {IEEE},
+@INPROCEEDINGS{11369551,
+  author={Avula, Ramana Reddy and Damschen, Marvin and Mirzai, Aria and Lundgren, Karl and Farooqui, Ashfaq and Thorsén, Anders},
+  booktitle={2025 13th International Conference on Control, Mechatronics and Automation (ICCMA)},
+  title={WayWiseR: A Rapid Prototyping Platform for Validating Connected and Automated Vehicles},
+  year={2025},
+  pages={306-311},
+  doi={10.1109/ICCMA67641.2025.11369551}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ If you use WayWiseR in your research, please cite:
 
 ```bibtex
 @INPROCEEDINGS{11369551,
-  author={Avula, Ramana Reddy and Damschen, Marvin and Mirzai, Aria and Lundgren, Karl and Farooqui, Ashfaq and Thorsén, Anders},
+  author={Avula, Ramana Reddy and Damschen, Marvin and Mirzai, Aria and Lundgren, Karl and Farooqui, Ashfaq and Thors\'{e}n, Anders},
   booktitle={2025 13th International Conference on Control, Mechatronics and Automation (ICCMA)},
   title={WayWiseR: A Rapid Prototyping Platform for Validating Connected and Automated Vehicles},
   year={2025},


### PR DESCRIPTION
### Pre-submission Checklist

Before creating this PR, ensure you have completed the following by filling in the checkboxes with 'x':

- [x] Followed the [Developer Guide](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR/blob/humble/.github/DEVELOPER_GUIDE.md) and coding standards
- [x] Run all tests: `colcon test --base-paths src/WayWiseR/ --packages-skip $WAYWISER_SKIPPED_PACKAGES`
- [x] Verified test results: `colcon test-result --verbose`

---

### Description

- **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  > Docs update

- **What is the current behavior?** (You can also link to an open issue here)

  > 1. The uv venv command in the README relies on the system default or uv's default Python version. On some systems (like standard Ubuntu 22.04), this can default to Python 3.8, causing dependency resolution failures for packages that require Python >= 3.10.
  > 2. The citation in the README was missing the DOI and correct page numbers for the ICCMA 2025 publication.

- **What is the new behavior (if this is a feature change)?**

  > 1. The installation instructions now explicitly specify uv venv --python 3.10, ensuring the correct Python version is used for the environment regardless of system defaults.
  > 2. The BibTeX citation has been updated with the published DOI and correct page numbers.

- **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

  > No

- **Other information**:

  >
