### PR TITLE
fix: update repository links to das-rise

### DIFF
--- a/.github/DEVELOPER_GUIDE.md
+++ b/.github/DEVELOPER_GUIDE.md
@@ -102,7 +102,7 @@ Before running the pipeline for the first time or after changing the CI environm
 ```bash
 # Build the CI image
 cd $WAYWISER_WS/src/WayWiseR
-docker build -t ghcr.io/rise-dependable-transport-systems/waywiser/ci-image:humble -f .github/workflows/Dockerfile.ci .
+docker build -t ghcr.io/das-rise/waywiser/ci-image:humble -f .github/workflows/Dockerfile.ci .
 ```
 
 Then, run the build and test job using `act`. The `--pull=false` flag ensures `act` uses your local image:
@@ -110,5 +110,5 @@ Then, run the build and test job using `act`. The `--pull=false` flag ensures `a
 ```bash
 # Run the CI pipeline locally
 cd $WAYWISER_WS/src/WayWiseR
-act -j build-and-test --pull=false -P ubuntu-22.04=ghcr.io/rise-dependable-transport-systems/waywiser/ci-image:humble
+act -j build-and-test --pull=false -P ubuntu-22.04=ghcr.io/das-rise/waywiser/ci-image:humble
 ```

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 Before creating this PR, ensure you have completed the following by filling in the checkboxes with 'x':
 
-- [ ] Followed the [Developer Guide](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR/blob/humble/.github/DEVELOPER_GUIDE.md) and coding standards
+- [ ] Followed the [Developer Guide](https://github.com/das-rise/WayWiseR/blob/humble/.github/DEVELOPER_GUIDE.md) and coding standards
 - [ ] Run all tests: `colcon test --base-paths src/WayWiseR/ --packages-skip $WAYWISER_SKIPPED_PACKAGES`
 - [ ] Verified test results: `colcon test-result --verbose`
 

--- a/.github/workflows/Dockerfile.ci
+++ b/.github/workflows/Dockerfile.ci
@@ -41,7 +41,7 @@ RUN rosdep update
 # Pre-install project and external dependencies
 # 1. Setup workspace and clone all repositories (WayWiseR + carla-ros-bridge)
 RUN mkdir -p /tmp/ws/src && \
-    printf "repositories:\n  WayWiseR:\n    type: git\n    url: https://github.com/RISE-Dependable-Transport-Systems/WayWiseR.git\n    version: humble\n  carla_ros_bridge:\n    type: git\n    url: https://github.com/RISE-Dependable-Transport-Systems/carla-ros-bridge.git\n    version: v0.9.15-humble-dev" > /tmp/ws/deps.repos && \
+    printf "repositories:\n  WayWiseR:\n    type: git\n    url: https://github.com/das-rise/WayWiseR.git\n    version: humble\n  carla_ros_bridge:\n    type: git\n    url: https://github.com/das-rise/carla-ros-bridge.git\n    version: v0.9.15-humble-dev" > /tmp/ws/deps.repos && \
     vcs import /tmp/ws/src < /tmp/ws/deps.repos
 
 # 2. Recursive submodule update for project and external repos

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,7 +13,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-22.04
-    container: ghcr.io/rise-dependable-transport-systems/waywiser/ci-image:humble
+    container: ghcr.io/das-rise/waywiser/ci-image:humble
 
     steps:
       - name: Checkout
@@ -27,7 +27,7 @@ jobs:
           repositories:
             carla_ros_bridge:
               type: git
-              url: https://github.com/RISE-Dependable-Transport-Systems/carla-ros-bridge.git
+              url: https://github.com/das-rise/carla-ros-bridge.git
               version: v0.9.15-humble-dev
           EOF
 

--- a/.github/workflows/docker-ci.yaml
+++ b/.github/workflows/docker-ci.yaml
@@ -37,7 +37,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ghcr.io/rise-dependable-transport-systems/waywiser/ci-image
+          images: ghcr.io/das-rise/waywiser/ci-image
           tags: |
             type=raw,value=humble
 

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "waywiser_core/WayWise"]
 path = waywiser_core/WayWise
-url = https://github.com/RISE-Dependable-Transport-Systems/WayWise.git
+url = https://github.com/das-rise/WayWise.git

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # WayWiseR
 
-![Workflow build result](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR/actions/workflows/build.yaml/badge.svg) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/RISE-Dependable-Transport-Systems/WayWiseR)
+![Workflow build result](https://github.com/das-rise/WayWiseR/actions/workflows/build.yaml/badge.svg) [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/das-rise/WayWiseR)
 
-**WayWiseR** is a [ROS2](https://docs.ros.org/)-based rapid prototyping platform designed for **Connected and Automated Vehicle (CAV)** validation research. Extending the low-level functionalities provided by the [WayWise](https://github.com/RISE-Dependable-Transport-Systems/WayWise) library with standardized ROS2 interfaces, WayWiseR enables systematic scenario-based validation across both simulated and physical environments.
+**WayWiseR** is a [ROS2](https://docs.ros.org/)-based rapid prototyping platform designed for **Connected and Automated Vehicle (CAV)** validation research. Extending the low-level functionalities provided by the [WayWise](https://github.com/das-rise/WayWise) library with standardized ROS2 interfaces, WayWiseR enables systematic scenario-based validation across both simulated and physical environments.
 
 WayWiseR is divided into modular ROS2 packages:
 
@@ -40,7 +40,7 @@ WayWiseR is divided into modular ROS2 packages:
      sudo dpkg -i libmavsdk-dev*.deb
      ```
 
-     Alternatively, MAVSDK can be built from source by using the scripts [here](https://github.com/RISE-Dependable-Transport-Systems/WayWise/tree/main/tools/build_MAVSDK).
+     Alternatively, MAVSDK can be built from source by using the scripts [here](https://github.com/das-rise/WayWise/tree/main/tools/build_MAVSDK).
 
    - Install system dependencies:
 
@@ -60,7 +60,7 @@ WayWiseR is divided into modular ROS2 packages:
    ```bash
    export WAYWISER_WS=~/waywiser_ws # Update with your desired path
    mkdir -p $WAYWISER_WS/src
-   git clone git@github.com:RISE-Dependable-Transport-Systems/WayWiseR.git $WAYWISER_WS/src/WayWiseR
+   git clone git@github.com:das-rise/WayWiseR.git $WAYWISER_WS/src/WayWiseR
    cd $WAYWISER_WS/src/WayWiseR
    git submodule update --init waywiser_core/WayWise
    ```

--- a/waywiser/package.xml
+++ b/waywiser/package.xml
@@ -10,7 +10,7 @@
 
   <license>GPLv3</license>
 
-  <url type="website">https://github.com/RISE-Dependable-Transport-Systems/WayWise</url>
+  <url type="website">https://github.com/das-rise/WayWise</url>
   <url type="website">https://docs.ros.org/en/humble/index.html</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/waywiser_carla/README.md
+++ b/waywiser_carla/README.md
@@ -8,7 +8,7 @@
    ```bash
    export CARLA_ROS_BRIDGE_WS=~/carla_ros_bridge_ws     # Update with desired path
    mkdir -p $CARLA_ROS_BRIDGE_WS/src
-   git clone --recurse-submodules git@github.com:RISE-Dependable-Transport-Systems/carla-ros-bridge.git $CARLA_ROS_BRIDGE_WS/src/carla-ros-bridge
+   git clone --recurse-submodules git@github.com:das-rise/carla-ros-bridge.git $CARLA_ROS_BRIDGE_WS/src/carla-ros-bridge
    ```
 
 2. **Install carla-ros-bridge dependencies:**
@@ -63,6 +63,6 @@ EOT
 
 ## CARLA OSM Tile Server
 
-The carla_osm_tile_server node implements a TCP/IP based server that generates map tiles from CARLA simulator data and serves them in a format similar to OpenStreetMap (OSM) tile servers, making WayWiseR compatible with OSM-based mapping applications like [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower). When the node is run for the first time, it connects to CARLA via ros-bridge and renders a 2D top-view image of the CARLA world, including roads and lane markings from opendrive data. The high-resolution map image is saved locally and is used to generate map tiles on demand.
+The carla_osm_tile_server node implements a TCP/IP based server that generates map tiles from CARLA simulator data and serves them in a format similar to OpenStreetMap (OSM) tile servers, making WayWiseR compatible with OSM-based mapping applications like [ControlTower](https://github.com/das-rise/ControlTower). When the node is run for the first time, it connects to CARLA via ros-bridge and renders a 2D top-view image of the CARLA world, including roads and lane markings from opendrive data. The high-resolution map image is saved locally and is used to generate map tiles on demand.
 
 <https://github.com/user-attachments/assets/edb4115a-6099-4ebc-97ff-f9e2919c92bc>

--- a/waywiser_core/README.md
+++ b/waywiser_core/README.md
@@ -1,6 +1,6 @@
 ## Overview
 
-The `waywiser_core` package contains ROS 2 nodes that wrap the [WayWise](https://github.com/RISE-Dependable-Transport-Systems/WayWise) vehicle prototyping library into ROS interfaces. These nodes bridge low-level vehicle control and sensor data with ROS topics and services, enabling ROS-based autonomy or autopilot features on WayWise-powered vehicles.
+The `waywiser_core` package contains ROS 2 nodes that wrap the [WayWise](https://github.com/das-rise/WayWise) vehicle prototyping library into ROS interfaces. These nodes bridge low-level vehicle control and sensor data with ROS topics and services, enabling ROS-based autonomy or autopilot features on WayWise-powered vehicles.
 
 ## Architecture
 
@@ -10,7 +10,7 @@ The package uses a component-based architecture with two main components:
 
 - **Autopilot Component** – Implements onboard autopilot using WayWise's route-following controllers (e.g., Pure Pursuit). This component enables autonomous driving by generating velocity commands based on:
   - a target path generated dynamically by a higher-level ROS2-based path planner (e.g. Nav2)
-  - a list of waypoints (set manually or using automated scripts) comminicated thorugh MAVLINK, using [ControlTower](https://github.com/RISE-Dependable-Transport-Systems/ControlTower).
+  - a list of waypoints (set manually or using automated scripts) comminicated thorugh MAVLINK, using [ControlTower](https://github.com/das-rise/ControlTower).
 
 ## Available Nodes
 

--- a/waywiser_core/package.xml
+++ b/waywiser_core/package.xml
@@ -10,7 +10,7 @@
 
   <license>GPLv3</license>
 
-  <url type="website">https://github.com/RISE-Dependable-Transport-Systems/WayWise</url>
+  <url type="website">https://github.com/das-rise/WayWise</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>rosidl_default_generators</buildtool_depend>

--- a/waywiser_hwbringup/package.xml
+++ b/waywiser_hwbringup/package.xml
@@ -11,7 +11,7 @@
 
   <license>GPLv3</license>
 
-  <url type="website">https://github.com/RISE-Dependable-Transport-Systems/WayWise</url>
+  <url type="website">https://github.com/das-rise/WayWise</url>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 

--- a/waywiser_twist_safety/README.md
+++ b/waywiser_twist_safety/README.md
@@ -26,4 +26,4 @@
 3. **emergency_stop_monitor**: Upon receiving a 'waywiser_twist_safety/msg/EmergencyStopState' type message with the state field set to '2' on the "/emergency_stop/target_state" topic, it suspends the input twist commands and publishes a zero-velocity twist command on its output topic. Instead, when the state field is set to '1', the emergency stop is deactivated, allowing the commands to pass through from the input to the output twist topics.
 
 A typical node graph would look as follows:
-![collision_monitor](https://github.com/RISE-Dependable-Transport-Systems/WayWiseR/assets/58977950/263c7c78-2cd9-4a8e-a50e-f1ab23c32e6e)
+![collision_monitor](https://github.com/das-rise/WayWiseR/assets/58977950/263c7c78-2cd9-4a8e-a50e-f1ab23c32e6e)


### PR DESCRIPTION
Updates repository links from the previous organization namespace to das-rise across the code base.